### PR TITLE
Use XDG spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Warning: Building Setzer this way may take a long time (~ 30 minutes on my lapto
 This way is probably a bit faster and may save you some disk space. I develop Setzer on Debian and that's what I tested it with. On Debian derivatives (like Ubuntu) it should probably work the same. On distributions other than Debian and Debian derivatives it should work more or less the same. If you want to run Setzer from source on another distribution and don't know how please open an issue here on GitHub. I will then try to provide instructions for your system.
 
 1. Run the following command to install prerequisite Debian packages:<br />
-`apt-get install libgtk-3-dev libgtksourceview-3.0-dev libpoppler-glib-dev libgspell-1-dev`
+`apt-get install libgtk-3-dev libgtksourceview-3.0-dev libpoppler-glib-dev libgspell-1-dev python3-xdg`
 
 2. Download und Unpack Setzer from GitHub
 

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ dependency('gspell-1')
 # python configuration
 python_modules = [
   'gi',
+  'xdg',
 ]
 if meson.version().version_compare('>=0.51')
   py = import('python').find_installation(modules: python_modules)

--- a/org.cvfosammmm.Setzer.json
+++ b/org.cvfosammmm.Setzer.json
@@ -89,6 +89,20 @@
             ]
         },
         {
+            "name": "python3-pyxdg",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} pyxdg"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/39/03/12eb9062f43adb94e30f366743cb5c83fd15fef026500cd4de42c7c12280/pyxdg-0.26-py2.py3-none-any.whl",
+                    "sha256": "1948ff8e2db02156c0cccd2529b43c0cff56ebaa71f5f021bbd755bc1419190e"
+                }
+            ]
+        },
+        {
             "name": "setzer",
             "buildsystem": "meson",
             "config-opts": [

--- a/setzer/app/service_locator.py
+++ b/setzer/app/service_locator.py
@@ -17,6 +17,7 @@
 
 import re
 import os.path
+from xdg.BaseDirectory import xdg_config_home
 
 import setzer.app.settings as settingscontroller
 import setzer.helpers.popover_menu_builder as popover_menu_builder
@@ -124,8 +125,8 @@ class ServiceLocator(object):
             ServiceLocator.popover_menu_builder = popover_menu_builder.PopoverMenuBuilder()
         return ServiceLocator.popover_menu_builder
 
-    def get_dot_folder():
-        return os.path.expanduser('~') + '/.setzer'
+    def get_config_folder():
+        return os.path.join(xdg_config_home, 'setzer')
 
     def init_setzer_version(setzer_version):
         ServiceLocator.setzer_version = setzer_version

--- a/setzer/document/state_manager/state_manager_bibtex.py
+++ b/setzer/document/state_manager/state_manager_bibtex.py
@@ -22,7 +22,7 @@ class StateManagerBibTeX():
 
     def __init__(self, document):
         self.document = document
-        self.data_pathname = ServiceLocator.get_dot_folder()
+        self.data_pathname = ServiceLocator.get_config_folder()
 
     def load_document_state(self):
         pass

--- a/setzer/document/state_manager/state_manager_latex.py
+++ b/setzer/document/state_manager/state_manager_latex.py
@@ -26,7 +26,7 @@ class StateManagerLaTeX():
 
     def __init__(self, document):
         self.document = document
-        self.data_pathname = ServiceLocator.get_dot_folder()
+        self.data_pathname = ServiceLocator.get_config_folder()
 
     def load_document_state(self):
         if self.document.filename == None: return

--- a/setzer/workspace/workspace.py
+++ b/setzer/workspace/workspace.py
@@ -37,7 +37,7 @@ class Workspace(Observable):
 
     def __init__(self):
         Observable.__init__(self)
-        self.pathname = ServiceLocator.get_dot_folder()
+        self.pathname = ServiceLocator.get_config_folder()
 
         self.open_documents = list()
         self.open_latex_documents = list()


### PR DESCRIPTION
If I get it right some config file can get into `~/.setzer/`, however it's better to follow the [XDG spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) and put them into `~/.config/setzer/`, this prevents the home dir to become a collection of random config files and dirs.
I also added an improved python dependency check which works with older versions of meson (Edit: moved that to #45).