### PR TITLE
Use SPDX license identifier in meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'Setzer',
   version: '0.2.3',
-  license: 'GPLv3',
+  license: 'GPL-3.0-or-later',
 )
 
 # runtime dependencies


### PR DESCRIPTION
Just a minor clarification that it is licensed under GPL version 3 or later using the [SPDX 3.0 spec](https://spdx.org/license-list).