### PR TITLE
improve local startup script

### DIFF
--- a/scripts/setzer.dev
+++ b/scripts/setzer.dev
@@ -16,11 +16,15 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>
 
 import sys
-import os
+import os.path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.dont_write_bytecode = True
 
-try:
-  import builddir.setzer_dev
-except ModuleNotFoundError:
+src_path = os.path.join(os.path.dirname(__file__), '..')
+bld_path = os.path.join(src_path, 'builddir')
+
+if os.path.isdir(bld_path):
+  sys.path.insert(0, src_path)
+  from builddir import setzer_dev
+else:
   print('Make sure to run `meson builddir` first.')


### PR DESCRIPTION
We shouldn't just check if there is a `ModuleNotFoundError`, since that could hide missing modules inside the code, instead we should check if `builddir/` exists.
Also, I added a line to prevent bytecode (`__pycache__` etc) from being written. I don't think it's a big performance hit, but it helps to keep a clean source dir (also helpful when building the debian package, don't have to run `py3clean .` with this).