### PR TITLE
Dependency on gir instead of dev-libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Warning: Building Setzer this way may take a long time (~ 30 minutes on my lapto
 This way is probably a bit faster and may save you some disk space. I develop Setzer on Debian and that's what I tested it with. On Debian derivatives (like Ubuntu) it should probably work the same. On distributions other than Debian and Debian derivatives it should work more or less the same. If you want to run Setzer from source on another distribution and don't know how please open an issue here on GitHub. I will then try to provide instructions for your system.
 
 1. Run the following command to install prerequisite Debian packages:<br />
-`apt-get install libgtk-3-dev libgtksourceview-3.0-dev libpoppler-glib-dev libgspell-1-dev python3-xdg`
+`apt-get install python3-gi gir1.2-gtk-3.0 gir1.2-gtksource-3.0 gir1.2-gspell-1 gir1.2-poppler-0.18 python3-xdg`
 
 2. Download und Unpack Setzer from GitHub
 

--- a/meson.build
+++ b/meson.build
@@ -4,33 +4,11 @@ project(
   license: 'GPL-3.0-or-later',
 )
 
-# runtime dependencies
-dependency('gtk+-3.0')
-dependency('gtksourceview-3.0')
-dependency('poppler-glib')
-dependency('gspell-1')
-
-# python configuration
-python_modules = [
-  'gi',
-  'xdg',
-]
-if meson.version().version_compare('>=0.51')
-  py = import('python').find_installation(modules: python_modules)
-else
-  py = import('python').find_installation()
-  foreach module: python_modules
-    if run_command(py, '-c', 'import @0@'.format(module)).returncode() != 0
-      error('Failed to find required python module "@0@".'.format(module))
-    endif
-  endforeach
-endif
-
 # configure folders
 prefix = get_option('prefix')
 bindir = get_option('bindir')
 datadir = get_option('datadir')
-pymdir = py.get_install_dir()
+pymdir = import('python').find_installation().get_install_dir()
 resourcesdir = join_paths(datadir, 'Setzer')
 localedir = get_option('localedir')
 


### PR DESCRIPTION
The dev libs aren't actually needed, they install way more than what's actually necessary to run Setzer. On Debian, you need `python3-gi`, which provides the GLib Python module, and it can be extended using the `gir` packages.
I also removed any dependency checks in Meson, first because they don't really work easily with the gir packages, and second because when building a distro package it creates unnecessary build dependencies (which means longer build times).
