### PR TITLE
more dependencies in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Warning: Building Setzer this way may take a long time (~ 30 minutes on my lapto
 This way is probably a bit faster and may save you some disk space. I develop Setzer on Debian and that's what I tested it with. On Debian derivatives (like Ubuntu) it should probably work the same. On distributions other than Debian and Debian derivatives it should work more or less the same. If you want to run Setzer from source on another distribution and don't know how please open an issue here on GitHub. I will then try to provide instructions for your system.
 
 1. Run the following command to install prerequisite Debian packages:<br />
-`apt-get install python3-gi gir1.2-gtk-3.0 gir1.2-gtksource-4 gir1.2-gspell-1 gir1.2-poppler-0.18 python3-xdg`
+`apt-get install python3-gi gir1.2-gtk-3.0 gir1.2-gtksource-4 gir1.2-gspell-1 gir1.2-pango-1.0 gir1.2-poppler-0.18 python3-xdg gettext`
 
 2. Download und Unpack Setzer from GitHub
 


### PR DESCRIPTION
I noticed that you import Pango from gi in 0637571b6b38e35c1e645e0adc86efbc940cd12f, so it should be added as dependency.
Same for gettext, it isn't required to run Setzer (afaik) but it is required to build the translations. I'm actually not sure if gettext has to be added to the flatpak build as well. Edit: https://github.com/flathub/flathub/wiki/AppData-Guidelines