### PR TITLE
localize metainfo

### DIFF
--- a/data/org.cvfosammmm.Setzer.appdata.xml.in
+++ b/data/org.cvfosammmm.Setzer.appdata.xml.in
@@ -4,9 +4,9 @@
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0+</project_license>
 	<content_rating type="oars-1.1" />
-	<name>Setzer</name>
+	<name translatable="no">Setzer</name>
 	<summary>Simple yet full-featured LaTeX editor</summary>
-    <developer_name>Cvfosammmm</developer_name>
+    <developer_name translatable="no">Cvfosammmm</developer_name>
 
 	<description>
 		<p>Setzer lets you Write LaTeX documents with an easy to use yet full-featured editor.</p>
@@ -23,6 +23,7 @@
 	</description>
 
 	<launchable type="desktop-id">org.cvfosammmm.Setzer.desktop</launchable>
+    <translation type="gettext">setzer</translation>
 
 	<screenshots>
     	<screenshot type="default">

--- a/data/org.cvfosammmm.Setzer.appdata.xml.in
+++ b/data/org.cvfosammmm.Setzer.appdata.xml.in
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
     <id>org.cvfosammmm.Setzer</id>
-	<metadata_license>CC0-1.0</metadata_license>
-	<project_license>GPL-3.0+</project_license>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>GPL-3.0-or-later</project_license>
 	<content_rating type="oars-1.1" />
 	<name translatable="no">Setzer</name>
 	<summary>Simple yet full-featured LaTeX editor</summary>

--- a/meson.build
+++ b/meson.build
@@ -50,11 +50,6 @@ install_data(
   install_dir: join_paths(datadir, 'icons', 'hicolor', 'scalable', 'apps'),
 )
 
-install_data(
-  join_paths('data', 'org.cvfosammmm.Setzer.appdata.xml'),
-  install_dir: join_paths(datadir, 'metainfo'),
-)
-
 install_man(
   join_paths('data', 'setzer.1'),
   install_dir: mandir,

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -47,3 +47,4 @@ setzer/workspace/sidebar/sidebar_viewgtk.py
 setzer/workspace/sidebar/sidebar.py
 setzer/workspace/workspace_viewgtk.py
 setzer/workspace/workspace.py
+data/org.cvfosammmm.Setzer.appdata.xml.in

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,5 +1,14 @@
 i18n = import('i18n')
 
+i18n.merge_file(
+    input:  join_paths(meson.source_root(), 'data', 'org.cvfosammmm.Setzer.appdata.xml.in'),
+    output: 'org.cvfosammmm.Setzer.appdata.xml',
+    type: 'xml',
+    po_dir: join_paths(meson.source_root(), 'po'),
+    install: true,
+    install_dir: join_paths(datadir, 'metainfo'),
+)
+
 i18n.gettext(
   'setzer',
   install_dir: localedir,


### PR DESCRIPTION
I localized the metainfo file (the desktop file should be possible as well). I also changed the license identifiers in the metainfo: the project license now uses the SPDX 3.0 identifier, and I changed the license of the metainfo file itself to the [FSFAP](https://spdx.org/licenses/FSFAP.html). The FSFAP doesn't require any copyright notice, so it solves any problems that might occur when trying to specify what license the translation files should have.