### PR TITLE
removes dots in appdata screenshot captions

### DIFF
--- a/data/org.cvfosammmm.Setzer.appdata.xml.in
+++ b/data/org.cvfosammmm.Setzer.appdata.xml.in
@@ -27,19 +27,19 @@
 
     <screenshots>
         <screenshot type="default">
-            <caption>Buttons and shortcuts for many LaTeX elements and special characters.</caption>
+            <caption>Buttons and shortcuts for many LaTeX elements and special characters</caption>
             <image>https://www.cvfosammmm.org/setzer/images/screenshot-symbols-appdata.png</image>
         </screenshot>
         <screenshot>
-            <caption>Document creation wizard.</caption>
+            <caption>Document creation wizard</caption>
             <image>https://www.cvfosammmm.org/setzer/images/screenshot-wizard-appdata.png</image>
         </screenshot>
         <screenshot>
-            <caption>Dark mode.</caption>
+            <caption>Dark mode</caption>
             <image>https://www.cvfosammmm.org/setzer/images/screenshot-dark-mode-appdata.png</image>
         </screenshot>
         <screenshot>
-            <caption>Helpful error messages in the build log.</caption>
+            <caption>Helpful error messages in the build log</caption>
             <image>https://www.cvfosammmm.org/setzer/images/screenshot-build-log-appdata.png</image>
         </screenshot>
     </screenshots>


### PR DESCRIPTION
For translations, since the strings are the same as in the description except the dot.