### PR TITLE
meson: add subdirs and tests

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,23 @@
+install_data(
+  files('org.cvfosammmm.Setzer.desktop'),
+  install_dir: join_paths(datadir, 'applications'),
+)
+
+install_data(
+  files('org.cvfosammmm.Setzer.svg'),
+  install_dir: join_paths(datadir, 'icons', 'hicolor', 'scalable', 'apps'),
+)
+
+metainfo_file = i18n.merge_file(
+  input:  files('org.cvfosammmm.Setzer.appdata.xml.in'),
+  output: 'org.cvfosammmm.Setzer.appdata.xml',
+  type: 'xml',
+  po_dir: join_paths(meson.source_root(), 'po'),
+  install: true,
+  install_dir: join_paths(datadir, 'metainfo'),
+)
+
+install_man(
+  files('setzer.1'),
+  install_dir: mandir,
+)

--- a/meson.build
+++ b/meson.build
@@ -40,20 +40,7 @@ install_subdir(
 )
 
 # install program data
-install_data(
-  join_paths('data', 'org.cvfosammmm.Setzer.desktop'),
-  install_dir: join_paths(datadir, 'applications'),
-)
-
-install_data(
-  join_paths('data', 'org.cvfosammmm.Setzer.svg'),
-  install_dir: join_paths(datadir, 'icons', 'hicolor', 'scalable', 'apps'),
-)
-
-install_man(
-  join_paths('data', 'setzer.1'),
-  install_dir: mandir,
-)
+subdir('data')
 
 # install binary
 configure_file(
@@ -70,3 +57,6 @@ configure_file(
   output: 'setzer_dev.py',
   configuration: config_dev,
 )
+
+# run tests
+subdir('tests')

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,14 +1,5 @@
 i18n = import('i18n')
 
-i18n.merge_file(
-    input:  join_paths(meson.source_root(), 'data', 'org.cvfosammmm.Setzer.appdata.xml.in'),
-    output: 'org.cvfosammmm.Setzer.appdata.xml',
-    type: 'xml',
-    po_dir: join_paths(meson.source_root(), 'po'),
-    install: true,
-    install_dir: join_paths(datadir, 'metainfo'),
-)
-
 i18n.gettext(
   'setzer',
   install_dir: localedir,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,12 @@
+# Validate MetaInfo file
+appstreamcli = find_program(
+  'appstreamcli',
+  required: false
+)
+if appstreamcli.found()
+  test(
+    'validate metainfo file',
+    appstreamcli,
+    args: ['validate', '--no-net', '--pedantic', metainfo_file],
+  )
+endif


### PR DESCRIPTION
Put all program data related stuff in an own `meson.build` file like with the po dir. I also added a `tests` subdir, currently the only test is for the MetaInfo.