### PR TITLE
meson: add flake8 test

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,12 +1,25 @@
 # Validate MetaInfo file
 appstreamcli = find_program(
   'appstreamcli',
-  required: false
+  required: false,
 )
 if appstreamcli.found()
   test(
     'validate metainfo file',
     appstreamcli,
     args: ['validate', '--no-net', '--pedantic', metainfo_file],
+  )
+endif
+
+# Test PEP 8 conformance
+flake8 = find_program(
+  'flake8',
+  required: false,
+)
+if flake8.found()
+  test(
+    'test PEP 8 conformance',
+    flake8,
+    args: ['--builtins=_'],
   )
 endif


### PR DESCRIPTION
Adds flake8 as test. flake8 test conformance to the PEP 8 Python Styling Guide. Currently the test will fail, I'll look into it and how to fix at least some of the warnings (every warning can be disabled if you don't like the style).

Btw to run the tests run `meson test -C builddir`.