### PR TITLE
add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{py,py.in}]
+indent_style = space
+indent_size = 4
+
+[*meson.build]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Helps to solve some problems that flake8 reports (trailing whitespaces etc). I think it should also be possible to add a meson test, but I'm still looking into that.

Edit: I found [this](https://github.com/editorconfig-checker/editorconfig-checker), it's not in Debian but I think I will pack it.