### PR TITLE
man page updates

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -17,7 +17,16 @@ metainfo_file = i18n.merge_file(
   install_dir: join_paths(datadir, 'metainfo'),
 )
 
+config_man = configuration_data()
+config_man.set('VERSION', meson.project_version())
+
+man_file = configure_file(
+  input: files('setzer.1.in'),
+  output: 'setzer.1',
+  configuration: config_man,
+)
+
 install_man(
-  files('setzer.1'),
+  man_file,
   install_dir: join_paths(mandir, 'man1'),
 )

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,13 +1,16 @@
+# .desktop file
 install_data(
   files('org.cvfosammmm.Setzer.desktop'),
   install_dir: join_paths(datadir, 'applications'),
 )
 
+# icon
 install_data(
   files('org.cvfosammmm.Setzer.svg'),
   install_dir: join_paths(datadir, 'icons', 'hicolor', 'scalable', 'apps'),
 )
 
+# metainfo
 metainfo_file = i18n.merge_file(
   input:  files('org.cvfosammmm.Setzer.appdata.xml.in'),
   output: 'org.cvfosammmm.Setzer.appdata.xml',
@@ -17,6 +20,7 @@ metainfo_file = i18n.merge_file(
   install_dir: join_paths(datadir, 'metainfo'),
 )
 
+# man page
 config_man = configuration_data()
 config_man.set('VERSION', meson.project_version())
 

--- a/data/meson.build
+++ b/data/meson.build
@@ -19,5 +19,5 @@ metainfo_file = i18n.merge_file(
 
 install_man(
   files('setzer.1'),
-  install_dir: mandir,
+  install_dir: join_paths(mandir, 'man1'),
 )

--- a/data/setzer.1.in
+++ b/data/setzer.1.in
@@ -1,5 +1,5 @@
 .\" Generated with help2man.
-.TH SETZER "1"
+.TH SETZER "1" "" "@VERSION@" "User Commands"
 .SH NAME
 Setzer \- simple yet full-featured LaTeX editor
 .SH DESCRIPTION


### PR DESCRIPTION
Closes #97.

The man page now also includes the version, as it's commonly done. Btw the second `""` is for the date, but that doesn't really make sense here since it's not a cmdline tool.
