### PR TITLE
[ADD] MIME type for session files

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -10,6 +10,12 @@ install_data(
   install_dir: join_paths(datadir, 'icons', 'hicolor', 'scalable', 'apps'),
 )
 
+# MIME type
+install_data(
+  files('org.cvfosammmm.Setzer.mime.xml'),
+  install_dir: join_paths(datadir, 'mime', 'packages'),
+)
+
 # metainfo
 metainfo_file = i18n.merge_file(
   input:  files('org.cvfosammmm.Setzer.appdata.xml.in'),

--- a/data/org.cvfosammmm.Setzer.desktop
+++ b/data/org.cvfosammmm.Setzer.desktop
@@ -5,4 +5,4 @@ Type=Application
 Icon=org.cvfosammmm.Setzer
 Categories=GNOME;GTK;Science;Office;
 Keywords=latex;bibtex;editor;
-MimeType=text/x-tex;text/x-bibtex;
+MimeType=application/vdn.setzer.session.stzs;text/x-tex;text/x-bibtex;

--- a/data/org.cvfosammmm.Setzer.mime.xml
+++ b/data/org.cvfosammmm.Setzer.mime.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+    <mime-type type="application/vdn.setzer.session.stzs">
+        <comment>Setzer Session</comment>
+        <glob pattern="*.stzs" weight="5"/>
+        <icon name="org.cvfosammmm.Setzer"/>
+    </mime-type>
+</mime-info>


### PR DESCRIPTION
## Related to [Issue #100](https://github.com/cvfosammmm/Setzer/issues/100)

Regarding to [Adding MIME types](https://developer.gnome.org/integration-guide/stable/mime.html.en#ex-mime-xml) and according to [Add a custom MIME type for individual users](https://help.gnome.org/admin/system-admin-guide/stable/mime-types-custom-user.html.en) we should now be able to open Setzer session files from the file manager. I also add an icon for this mime type.

---

### Test Procedure:

#### Integration Test:
1. Open  Setzer, create a session file.
2. In the file manager, you should see this file with the Setzer icon.
3. Double click on the file should open this session in Setzer.
    _Expected result:_
    - Setzer open and restore the session file.

#### Unit Test:
1. From a shell run `gio info my_test_session.stzs | grep "standard::content-type"`
    _Expected result:_
    - `standard::content-type: application/vdn.setzer.session.stzs`
2. From a shell run `gio mime application/vdn.setzer.session.stzs`
    _Expected result:_
    - `Default application for “application/vdn.setzer.session.stzs”: org.cvfosammmm.Setzer.desktop`

---

@stephanlachnit may you review it please ?
Thx in advance