### PR TITLE
[ADD] version to cmdline

### DIFF
--- a/setzer.in
+++ b/setzer.in
@@ -19,6 +19,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from gi.repository import Gio
+from gi.repository import GLib
 
 import sys
 import gettext
@@ -28,11 +29,19 @@ import setzer.workspace.workspace_viewgtk as view
 from setzer.app.service_locator import ServiceLocator
 from setzer.dialogs.dialog_locator import DialogLocator
 
-
 class MainApplicationController(Gtk.Application):
 
-    def __init__(self):
-        Gtk.Application.__init__(self, application_id='org.cvfosammmm.Setzer', flags=Gio.ApplicationFlags.HANDLES_OPEN)
+    def __init__(self, **kwargs):
+        Gtk.Application.__init__(self, application_id='org.cvfosammmm.Setzer', flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE, **kwargs)
+        # Register a new commandline option
+        self.add_main_option(
+            "version",
+            ord("v"),
+            GLib.OptionFlags.NONE,
+            GLib.OptionArg.NONE,
+            "Output version information and exit",
+            None,
+        )
 
     def do_startup(self):
         ''' Everything starts here. '''
@@ -118,6 +127,18 @@ class MainApplicationController(Gtk.Application):
         # init controller
         self.workspace.init_workspace_controller()
         self.main_window.quit_action.connect('activate', self.on_quit_action)
+
+    def do_command_line(self, command_line):
+        options = command_line.get_options_dict()
+        # Convert GVariantDict -> GVariant -> dict
+        options = options.end().unpack()
+
+        if "version" in options:
+            print("Setzer version: %s" % ServiceLocator.get_setzer_version())
+            self.quit()
+        else:
+            self.activate()
+        return True
 
     def on_window_size_allocate(self, main_window, window_size):
         ''' signal handler, update window size variables '''


### PR DESCRIPTION
# Related to [issue 105](https://github.com/cvfosammmm/Setzer/issues/105)

According to [GtkApplication](https://developer.gnome.org/GtkApplication/) and [gnome.org/CommandLine](https://developer.gnome.org/CommandLine/) we have 2 options to handle command line:

1. `handle-local-options` which is the default option
2. `G_APPLICATION_HANDLES_COMMAND_LINE` a more advance an controllable option

At first, I tried to implement `handle-local-options`, which was enough to handle a `--version` flag, but at last, I was unable to handle a second `-v` flag. So, I decide to move to the `G_APPLICATION_HANDLES_COMMAND_LINE` option.
As you can see I changed the `Gtk.Application.__init__` flag from `Gio.ApplicationFlags.HANDLES_OPEN` to `Gio.ApplicationFlags.HANDLES_COMMAND_LINE`.

In the [Gio.Application.run](https://lazka.github.io/pgi-docs/Gio-2.0/classes/Application.html#Gio.Application.run) documentation, we can read this paragraph

> What happens next depends on the flags: if Gio.ApplicationFlags.HANDLES_COMMAND_LINE was specified then the remaining commandline arguments are sent to the primary instance, where a Gio.Application ::command-line signal is emitted. Otherwise, the remaining commandline arguments are assumed to be a list of files. If there are no files listed, the application is activated via the Gio.Application ::activate signal. If there are one or more files, and Gio.ApplicationFlags.HANDLES_OPEN was specified then the files are opened via the Gio.Application ::open signal.

In fact, if we have a `HANDLES_COMMAND_LINE` flag set, it result at the end a `HANDLES_OPEN` flag if nothing special append.

But, to be more confident to not break the existing, I did a lot of manual tests with both _Flatpak_ and _local_ install.

You can find [here](https://python-gtk-3-tutorial.readthedocs.io/en/latest/application.html#command-line) a command line example. 

---

### Test Procedure:

1. Open Setzer via the Icon or the cli (without any options)
    _Expected result:_
     - Setzer open and restore the session file as expected.
2. Open Setzer via the cli with `setzer -h` or `flatpak run org.cvfosammmm.Setzer -h`
    _Expected result:_
     - Setzer display the help message and you now able to see `-v, --version` option in the `Application Options:` part.
3. Open Setzer via the cli with `setzer -v` or `setzer --version` or `flatpak run org.cvfosammmm.Setzer -v` or `flatpak run org.cvfosammmm.Setzer --version`
    _Expected result:_
     - Setzer display it's version `Setzer version: 0.2.9`

---

I did a rebase (2020/08/20 3 AM UTC) on your master branch to do some testing before this PR.
I tried to implement tests for this feature, I had a look on the test `meson.build` file, but I didn't understand how to do it for this feature. I will have a look to the meson documentation and I will be luckier next time.