### PR TITLE
Fix error when set_filename() is called with None

### DIFF
--- a/setzer/document/build_widget/build_widget.py
+++ b/setzer/document/build_widget/build_widget.py
@@ -48,7 +48,7 @@ class BuildWidget(Observable):
         self.document.build_system.connect('build_state', self.on_build_state)
         self.settings.connect('settings_changed', self.on_settings_changed)
 
-    def on_filename_change(self, document, filename):
+    def on_filename_change(self, document, filename=None):
         self.set_clean_button_state()
 
     def on_build_state_change(self, build_system, build_state):

--- a/setzer/document/document_switcher_item/document_switcher_item.py
+++ b/setzer/document/document_switcher_item/document_switcher_item.py
@@ -32,7 +32,7 @@ class DocumentSwitcherItem():
         self.document.connect('is_root_changed', self.on_is_root_changed)
         self.document.content.connect('modified_changed', self.on_modified_changed)
 
-    def on_filename_change(self, document, filename):
+    def on_filename_change(self, document, filename=None):
         self.view.set_name(self.document.get_displayname(), self.modified_state)
 
     def on_modified_changed(self, content):

--- a/setzer/document/preview/preview.py
+++ b/setzer/document/preview/preview.py
@@ -95,7 +95,7 @@ class Preview(Observable):
                 self.page_renderer.deactivate()
             thread.start_new_thread(self.update_links, ())
 
-    def on_filename_change(self, document, filename):
+    def on_filename_change(self, document, filename=None):
         self.set_pdf_filename_from_tex_filename(filename)
         self.set_pdf_date()
         self.load_pdf()

--- a/setzer/workspace/document_switcher/document_switcher_presenter.py
+++ b/setzer/workspace/document_switcher/document_switcher_presenter.py
@@ -65,7 +65,7 @@ class DocumentSwitcherPresenter(object):
     def on_docswitcher_mode_change(self, document_switcher, mode):
         self.activate_mode(mode)
 
-    def on_filename_change(self, document, filename):
+    def on_filename_change(self, document, filename=None):
         self.show_document_name(document)
 
     def on_displayname_change(self, document):


### PR DESCRIPTION
When set_filename() in Document is called with None (which is a valid behaviour), and calls on_filename_change() (which needs 3 arguments) through the Observable class, the None is lost when passing through add_change_code() which raises an error due to the missing filename argument. This commit changes all references to on_filename_change() to give a default None value to filename so its value is not lost, and the program can proceed without raising any error.

(Fixes rhbz#2036772)