### PR TITLE
Bugfix

### DIFF
--- a/setzer/document/build_system/build_system.py
+++ b/setzer/document/build_system/build_system.py
@@ -22,6 +22,7 @@ import _thread as thread, queue
 import time
 
 from setzer.app.service_locator import ServiceLocator
+from setzer.dialogs.dialog_locator import DialogLocator
 import setzer.document.build_system.builder.builder_build_latex as builder_build_latex
 import setzer.document.build_system.builder.builder_build_bibtex as builder_build_bibtex
 import setzer.document.build_system.builder.builder_build_biber as builder_build_biber

--- a/setzer/document/build_system/builder/builder_build_latex.py
+++ b/setzer/document/build_system/builder/builder_build_latex.py
@@ -55,7 +55,7 @@ class BuilderBuildLaTeX(builder_build.BuilderBuild):
         arguments.append(query.tex_filename)
         try:
             self.process = pexpect.spawn(build_command + ' -output-directory="' + os.path.dirname(query.tex_filename) + '" "' + query.tex_filename + '"', cwd=os.path.dirname(query.tex_filename))
-        except FileNotFoundError:
+        except pexpect.exceptions.ExceptionPexpect:
             self.cleanup_files(query)
             self.throw_build_error(query, 'interpreter_missing', arguments[0])
             return


### PR DESCRIPTION
This pull request fixes two bugs:

First, in `build_system`, `DialogLocator` was not imported. Due to that, if the interpreter is missing or the interpreter is not working, the code fails and there is no visual feedback to the user (apart from the fact that the building takes forever).

Second, wrong exception was handled in `builder_build_latex` : `pexpect` does not throw `FileNotFoundError`, instead it throws `expect.exceptions.ExceptionPexpect`. 

