### PR TITLE
Added dialog for displaying errors

### DIFF
--- a/setzer/dialogs/dialog_locator.py
+++ b/setzer/dialogs/dialog_locator.py
@@ -21,6 +21,7 @@ import setzer.dialogs.bibtex_wizard.bibtex_wizard as bibtex_wizard
 import setzer.dialogs.build_save.build_save as build_save_dialog
 import setzer.dialogs.building_failed.building_failed as building_failed_dialog
 import setzer.dialogs.close_confirmation.close_confirmation as close_confirmation_dialog
+import setzer.dialogs.display_errors.display_errors as display_errors
 import setzer.dialogs.document_wizard.document_wizard as document_wizard
 import setzer.dialogs.document_changed_on_disk.document_changed_on_disk as document_changed_on_disk_dialog
 import setzer.dialogs.document_deleted_on_disk.document_deleted_on_disk as document_deleted_on_disk_dialog
@@ -49,6 +50,7 @@ class DialogLocator(object):
         dialogs['bibtex_wizard'] = bibtex_wizard.BibTeXWizard(main_window, workspace)
         dialogs['building_failed'] = building_failed_dialog.BuildingFailedDialog(main_window)
         dialogs['build_save'] = build_save_dialog.BuildSaveDialog(main_window)
+        dialogs['display_errors'] = display_errors.DisplayErrors(main_window)
         dialogs['document_wizard'] = document_wizard.DocumentWizard(main_window, workspace)
         dialogs['document_changed_on_disk'] = document_changed_on_disk_dialog.DocumentChangedOnDiskDialog(main_window)
         dialogs['document_deleted_on_disk'] = document_deleted_on_disk_dialog.DocumentDeletedOnDiskDialog(main_window)

--- a/setzer/dialogs/display_errors/display_errors.py
+++ b/setzer/dialogs/display_errors/display_errors.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+# Copyright (C) 2017, 2018 Robert Griesel
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>
+
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import GLib
+from gi.repository import Gtk
+
+from setzer.dialogs.dialog import Dialog
+
+import os.path
+
+
+class DisplayErrors(Dialog):
+
+    def __init__(self, main_window):
+        self.main_window = main_window
+
+    def run(self, err: gi.repository.GLib.Error):
+        print("test_run")
+        self.setup(err.message)
+        response = self.view.run()
+        self.close()
+
+    def setup(self, error_message: str):
+        print(type(error_message))
+        self.view = Gtk.MessageDialog(
+            transient_for=self.main_window,
+            flags=0,
+            message_type=Gtk.MessageType.ERROR,
+            buttons=Gtk.ButtonsType.OK,
+            text=_('Something went wrong.'),
+        )
+        self.view.format_secondary_text(error_message)
+

--- a/setzer/dialogs/display_errors/display_errors.py
+++ b/setzer/dialogs/display_errors/display_errors.py
@@ -32,13 +32,11 @@ class DisplayErrors(Dialog):
         self.main_window = main_window
 
     def run(self, err: gi.repository.GLib.Error):
-        print("test_run")
         self.setup(err.message)
         response = self.view.run()
         self.close()
 
     def setup(self, error_message: str):
-        print(type(error_message))
         self.view = Gtk.MessageDialog(
             transient_for=self.main_window,
             flags=0,

--- a/setzer/document/preview/preview.py
+++ b/setzer/document/preview/preview.py
@@ -35,6 +35,7 @@ import setzer.document.preview.preview_links_parser as preview_links_parser
 import setzer.document.preview.preview_zoom_manager as preview_zoom_manager
 import setzer.document.preview.zoom_widget.zoom_widget as zoom_widget
 import setzer.document.preview.paging_widget.paging_widget as paging_widget
+from setzer.dialogs.dialog_locator import DialogLocator
 from setzer.helpers.observable import Observable
 from setzer.helpers.timer import timer
 
@@ -148,7 +149,8 @@ class Preview(Observable):
             self.poppler_document = Poppler.Document.new_from_file('file:' + self.pdf_filename)
         except TypeError:
             self.reset_pdf_data()
-        except gi.repository.GLib.Error:
+        except gi.repository.GLib.Error as err:
+            DialogLocator.get_dialog('display_errors').run(err)
             self.reset_pdf_data()
         else:
             page_size = self.poppler_document.get_page(0).get_size()


### PR DESCRIPTION
When there is a problem with unsupported character in the file path Setzer will now show error message: closes #292

![image](https://user-images.githubusercontent.com/77555700/209586698-013dbd54-1d6f-4c49-9792-b1d05f9e015c.png)

Unfortunately, I didn't find any solution how to fix it differently than showing an error. 


I'm not sure if it will be correctly translated into different languages. (line 47 in display_errors.py needs to be translated).