### PR TITLE
Show \todo{} items in document structure sidebar

### DIFF
--- a/setzer/document/document.py
+++ b/setzer/document/document.py
@@ -52,6 +52,8 @@ class Document(Observable):
         self.symbols['bibitems'] = set()
         self.symbols['labels'] = set()
         self.symbols['labels_with_offset'] = list()
+        self.symbols['todos'] = set()
+        self.symbols['todos_with_offset'] = set()
         self.symbols['included_latex_files'] = set()
         self.symbols['bibliographies'] = set()
         self.symbols['packages'] = set()
@@ -188,5 +190,11 @@ class Document(Observable):
 
     def get_labels_with_offset(self):
         return self.symbols['labels_with_offset']
+
+    def get_todos(self):
+        return self.symbols['todos']
+
+    def get_todos_with_offset(self):
+        return self.symbols['todos_with_offset']
 
 

--- a/setzer/document/parser/parser_latex.py
+++ b/setzer/document/parser/parser_latex.py
@@ -66,7 +66,7 @@ class ParserLaTeX(object):
         additional_matches = self.parse_for_blocks(text, line_start, offset_line_start)
         block_symbol_matches['begin_or_end'] += additional_matches['begin_or_end']
         block_symbol_matches['others'] += additional_matches['others']
-        for match in ServiceLocator.get_regex_object(r'\\(label|include|input|bibliography|addbibresource)\{((?:\s|\w|\:|\.|,|\/|\\|\'|-|\")*)\}|\\(usepackage)(?:\[[^\{\[]*\]){0,1}\{((?:\s|\w|\:|,)*)\}|\\(bibitem)(?:\[.*\]){0,1}\{((?:\s|\w|\:)*)\}').finditer(text):
+        for match in ServiceLocator.get_regex_object(r'\\(label|include|input|bibliography|addbibresource|todo)\{((?:\s|\w|\:|\.|,|\/|\\|\'|-|\"|\(|\))*)\}|\\(usepackage)(?:\[[^\{\[]*\]){0,1}\{((?:\s|\w|\:|,)*)\}|\\(bibitem)(?:\[.*\]){0,1}\{((?:\s|\w|\:)*)\}').finditer(text):
             other_symbols.append((match, match.start() + offset_line_start))
 
         for match in self.block_symbol_matches['begin_or_end']:
@@ -120,7 +120,7 @@ class ParserLaTeX(object):
         additional_matches = self.parse_for_blocks(text_parse, line_start, offset_line_start)
         block_symbol_matches['begin_or_end'] += additional_matches['begin_or_end']
         block_symbol_matches['others'] += additional_matches['others']
-        for match in ServiceLocator.get_regex_object(r'\\(label|include|input|bibliography|addbibresource)\{((?:\s|\w|\:|\.|,|\/|\\|\'|-|\")*)\}|\\(usepackage)(?:\[[^\{\[]*\]){0,1}\{((?:\s|\w|\:|,)*)\}|\\(bibitem)(?:\[.*\]){0,1}\{((?:\s|\w|\:)*)\}').finditer(text_parse):
+        for match in ServiceLocator.get_regex_object(r'\\(label|include|input|bibliography|addbibresource|todo)\{((?:\s|\w|\:|\.|,|\/|\\|\'|-|\"|\(|\))*)\}|\\(usepackage)(?:\[[^\{\[]*\]){0,1}\{((?:\s|\w|\:|,)*)\}|\\(bibitem)(?:\[.*\]){0,1}\{((?:\s|\w|\:)*)\}').finditer(text_parse):
             other_symbols.append((match, match.start() + offset_line_start))
 
         for match in self.block_symbol_matches['begin_or_end']:
@@ -226,6 +226,8 @@ class ParserLaTeX(object):
     def parse_symbols(self):
         labels = set()
         labels_with_offset = list()
+        todos = set()
+        todos_with_offset = list()
         included_latex_files = list()
         bibliographies = set()
         bibitems = set()
@@ -250,6 +252,9 @@ class ParserLaTeX(object):
                 bibfiles = match.group(2).strip().split(',')
                 for entry in bibfiles:
                     bibliographies = bibliographies | {entry.strip()}
+            elif match.group(1) == 'todo':
+                todos = todos | {match.group(2).strip()}
+                todos_with_offset.append([match.group(2).strip(), offset])
             elif match.group(3) == 'usepackage':
                 packages = packages | {match.group(4).strip()}
                 packages_detailed[match.group(4).strip()] = [offset, match]
@@ -259,6 +264,8 @@ class ParserLaTeX(object):
         self.document.symbols['labels'] = labels
         self.document.symbols['labels_with_offset'] = labels_with_offset
         self.document.symbols['included_latex_files'] = included_latex_files
+        self.document.symbols['todos'] = todos
+        self.document.symbols['todos_with_offset'] = todos_with_offset
         self.document.symbols['bibliographies'] = bibliographies
         self.document.symbols['bibitems'] = bibitems
         self.document.symbols['packages'] = packages

--- a/setzer/workspace/sidebar/document_structure_page/todos.py
+++ b/setzer/workspace/sidebar/document_structure_page/todos.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+# Copyright (C) 2017, 2018 Robert Griesel
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+from gi.repository import Gdk
+
+import setzer.workspace.sidebar.document_structure_page.structure_widget as structure_widget
+import setzer.workspace.sidebar.document_structure_page.todos_viewgtk as todos_section_view
+
+
+class TodosSection(structure_widget.StructureWidget):
+
+    def __init__(self, data_provider, todos):
+        structure_widget.StructureWidget.__init__(self, data_provider)
+
+        self.headline_labels = todos
+        self.view = todos_section_view.TodosSectionView()
+        self.init_view()
+
+        self.todos = list()
+
+    def on_button_press(self, drawing_area, event):
+        modifiers = Gtk.accelerator_get_default_mod_mask()
+
+        if event.type == Gdk.EventType.BUTTON_PRESS and event.button == 1 and event.state & modifiers == 0:
+            item_num = max(0, min(int((event.y - 9) // self.view.line_height), len(self.todos) - 1))
+
+            document = self.todos[item_num][2]
+            line_number = document.content.get_line_number_at_offset(self.todos[item_num][1])
+            self.data_provider.workspace.set_active_document(document)
+            document.content.place_cursor(line_number)
+            document.content.scroll_cursor_onscreen()
+            self.data_provider.workspace.active_document.view.source_view.grab_focus()
+
+    #@timer
+    def update_items(self, *params):
+        todos = list()
+        for todo in self.data_provider.document.get_todos_with_offset():#provide this function
+            document = self.data_provider.document
+            todo.append(document)
+            todos.append(todo)
+        for document in self.data_provider.integrated_includes:
+            for todo in document.get_todo_with_offset():
+                todo.append(document)
+                todos.append(todo)
+        todos.sort(key=lambda todo: todo[0].lower())
+        self.todos = todos
+
+        if len(todos) == 0:
+            self.height = 0
+            self.view.hide()
+            self.headline_labels['inline'].hide()
+            self.headline_labels['overlay'].hide()
+        else:
+            self.height = len(self.todos) * self.view.line_height + 33
+            self.view.show()
+            self.headline_labels['inline'].show()
+            self.headline_labels['overlay'].show()
+        self.view.set_size_request(-1, self.height)
+        self.set_hover_item(None)
+        self.view.queue_draw()
+
+    #@timer
+    def draw(self, drawing_area, ctx):
+        if len(self.todos) == 0:
+            return True
+
+        first_line, last_line = self.get_first_line_last_line(ctx)
+        self.drawing_setup(ctx)
+        self.draw_background(ctx)
+
+        for count, label in enumerate(self.todos):
+            if count >= first_line and count <= last_line:
+                self.draw_hover_background(ctx, count)
+                self.draw_icon(ctx, 'tag-symbolic', 9, count)
+                self.draw_text(ctx, 35, count, label[0])
+
+

--- a/setzer/workspace/sidebar/document_structure_page/todos_viewgtk.py
+++ b/setzer/workspace/sidebar/document_structure_page/todos_viewgtk.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+# Copyright (C) 2017, 2018 Robert Griesel
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+from gi.repository import Gdk
+from gi.repository import Pango
+
+
+class TodosSectionView(Gtk.DrawingArea):
+
+    def __init__(self):
+        Gtk.DrawingArea.__init__(self)
+
+        self.bg_color = None
+        self.hover_color = None
+        self.fg_color = None
+        self.icon_infos = dict()
+        self.icons = dict()
+
+        self.icon_infos['tag'] = Gtk.IconTheme.get_default().lookup_icon('tag-symbolic', 16 * self.get_scale_factor(), 0)
+
+        self.add_events(Gdk.EventMask.BUTTON_PRESS_MASK)
+        self.add_events(Gdk.EventMask.BUTTON_RELEASE_MASK)
+        self.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK)
+        self.add_events(Gdk.EventMask.LEAVE_NOTIFY_MASK)
+        self.add_events(Gdk.EventMask.POINTER_MOTION_MASK)
+
+        style_context = self.get_style_context()
+        self.font = style_context.get_font(style_context.get_state())
+        self.font_size = (self.font.get_size() * 4) / (3 * Pango.SCALE)
+        self.line_height = int(self.font_size) + 11
+
+

--- a/setzer/workspace/sidebar/document_structure_page/todos_viewgtk.py
+++ b/setzer/workspace/sidebar/document_structure_page/todos_viewgtk.py
@@ -33,7 +33,7 @@ class TodosSectionView(Gtk.DrawingArea):
         self.icon_infos = dict()
         self.icons = dict()
 
-        self.icon_infos['tag'] = Gtk.IconTheme.get_default().lookup_icon('tag-symbolic', 16 * self.get_scale_factor(), 0)
+        self.icon_infos['tag'] = Gtk.IconTheme.get_default().lookup_icon('starred-symbolic', 16 * self.get_scale_factor(), 0)
 
         self.add_events(Gdk.EventMask.BUTTON_PRESS_MASK)
         self.add_events(Gdk.EventMask.BUTTON_RELEASE_MASK)

--- a/setzer/workspace/sidebar/sidebar.py
+++ b/setzer/workspace/sidebar/sidebar.py
@@ -21,6 +21,7 @@ import setzer.workspace.sidebar.document_structure_page.data_provider as data_pr
 import setzer.workspace.sidebar.document_structure_page.files as files_section
 import setzer.workspace.sidebar.document_structure_page.structure as structure_section
 import setzer.workspace.sidebar.document_structure_page.labels as labels_section
+import setzer.workspace.sidebar.document_structure_page.todos as todos_section
 import setzer.workspace.sidebar.document_stats.document_stats as document_stats_section
 from setzer.app.service_locator import ServiceLocator
 
@@ -56,6 +57,10 @@ class Sidebar(object):
         self.document_structure_page.add_label('labels', _('Labels'))
         self.labels_section = labels_section.LabelsSection(self.data_provider, self.document_structure_page.labels['labels'])
         self.document_structure_page.add_content_widget('labels', self.labels_section.view)
+
+        self.document_structure_page.add_label('todos', _('To-Dos'))
+        self.todos_section = todos_section.TodosSection(self.data_provider, self.document_structure_page.labels['todos'])
+        self.document_structure_page.add_content_widget('todos', self.todos_section.view)
 
         self.document_structure_page.add_label('stats', _('Document Stats'))
         self.document_stats_section = document_stats_section.DocumentStats(self.workspace, self.document_structure_page.labels['stats'])


### PR DESCRIPTION
This change shows \todo{} items in the in the document structure navigator sidebar (essentially by copying the syntax for \label{}), and allows parantheses in label titles.

Since \todo{} isn't a latex primitive, people who use it either have to use packages like todonotes that provide it, or define the \todo{} command themselves. If you don't import or define it, the to-dos will still show up in the sidebar, but the document will fail to compile.

For people who don't use to-do commands (i.e. if it's not detected anywhere in the document), it won't show up in the sidebar -- that section of the sidebar is only active if there are todos present in the document.

The icon could maybe be changed, I just used the one that I usually use in my handwritten notes for tasks!