### PR TITLE
use the GLib filename_to_uri builtin to escape special characters in filepaths rather than manually constructing the file URI to avoid errors (bugfix #292)

### DIFF
--- a/setzer/document/preview/preview.py
+++ b/setzer/document/preview/preview.py
@@ -145,7 +145,7 @@ class Preview(Observable):
 
     def load_pdf(self):
         try:
-            self.poppler_document = Poppler.Document.new_from_file('file:' + self.pdf_filename)
+            self.poppler_document = Poppler.Document.new_from_file(GLib.filename_to_uri(self.pdf_filename))
         except TypeError:
             self.reset_pdf_data()
         except gi.repository.GLib.Error:


### PR DESCRIPTION
The error being thrown was `g_convert_error: The local file URI “file:/path/to#/document.pdf” may not include a “#” (4)`. The solution is to use GLib's built-in `filename_to_uri` function, which automatically escapes special characters. This fixes #292.