### PR TITLE
Add tectonic latex interpreter

### DIFF
--- a/setzer/dialogs/preferences/pages/page_build_system.py
+++ b/setzer/dialogs/preferences/pages/page_build_system.py
@@ -102,6 +102,7 @@ class PageBuildSystem(object):
             self.view.option_latex_interpreter['tectonic'].connect('toggled', self.on_use_tectonic_toggled)
             self.view.latexmk_enable_revealer.set_reveal_child(not self.view.option_latex_interpreter['tectonic'].get_active())
             self.view.shell_escape_revealer.set_reveal_child(not self.view.option_latex_interpreter['tectonic'].get_active())
+            self.view.tectonic_warning_revealer.set_reveal_child(self.view.option_latex_interpreter['tectonic'].get_active())
 
     def on_use_tectonic_toggled(self, button):
         self.view.latexmk_enable_revealer.set_reveal_child(not button.get_active())
@@ -110,6 +111,7 @@ class PageBuildSystem(object):
         self.view.shell_escape_revealer.set_reveal_child(not button.get_active())
         if (button.get_active()):
             self.settings.set_value('preferences', 'build_option_system_commands', 'disable')
+        self.view.tectonic_warning_revealer.set_reveal_child(button.get_active())
 
 class PageBuildSystemView(Gtk.VBox):
 
@@ -127,15 +129,6 @@ class PageBuildSystemView(Gtk.VBox):
         label.set_xalign(0)
         label.set_margin_bottom(6)
         self.pack_start(label, False, False, 0)
-
-        label = Gtk.Label()
-        label.set_line_wrap(True)
-        label.set_markup(_('Warning: if using Tectonic, make sure you do not require any shell escape features, as these are unsupported by the Tectonic command-line interface. Note also that this uses the V1 Tectonic interface, so Tectonic.toml configuration files will NOT be respected.'))
-        label.set_xalign(0)
-        label.set_margin_bottom(9)
-        label.get_style_context().add_class('description')
-        self.pack_start(label, False, False, 0)
-
 
         self.no_interpreter_label = Gtk.Label()
         self.no_interpreter_label.set_line_wrap(True)
@@ -160,6 +153,18 @@ class PageBuildSystemView(Gtk.VBox):
         self.hbox1.pack_start(self.option_latex_interpreter['lualatex'], False, False, 0)
         self.hbox1.pack_start(self.option_latex_interpreter['tectonic'], False, False, 0)
         self.pack_start(self.hbox1, False, False, 0)
+
+        self.tectonic_warning_revealer = Gtk.Revealer()
+        self.tectonic_warning_revealer.set_transition_type(Gtk.RevealerTransitionType.NONE)
+        label = Gtk.Label()
+        label.set_line_wrap(True)
+        label.set_markup(_('Warning: When using Tectonic, only the V1 command-line interface is used. Tectonic.toml configuration files will therefore NOT be respected.'))
+        label.set_xalign(0)
+        label.set_margin_bottom(9)
+        label.get_style_context().add_class('description')
+        self.tectonic_warning_revealer.add(label)
+        self.pack_start(self.tectonic_warning_revealer, False, False, 0)
+
 
         label = Gtk.Label()
         label.set_markup('<b>' + _('Options') + '</b>')

--- a/setzer/dialogs/preferences/pages/page_build_system.py
+++ b/setzer/dialogs/preferences/pages/page_build_system.py
@@ -171,7 +171,7 @@ class PageBuildSystemView(Gtk.VBox):
         self.pack_start(self.option_cleanup_build_files, False, False, 0)
 
         self.latexmk_enable_revealer = Gtk.Revealer()
-        self.latexmk_enable_revealer.set_transition_type(Gtk.RevealerTransitionType(0))
+        self.latexmk_enable_revealer.set_transition_type(Gtk.RevealerTransitionType.NONE)
         self.option_use_latexmk = Gtk.CheckButton(_('Use Latexmk'))
         self.latexmk_enable_revealer.add(self.option_use_latexmk)
         self.pack_start(self.latexmk_enable_revealer, False, False, 0)
@@ -190,7 +190,7 @@ class PageBuildSystemView(Gtk.VBox):
         self.pack_start(self.option_autoshow_build_log_all, False, False, 0)
     
         self.shell_escape_revealer = Gtk.Revealer()
-        self.shell_escape_revealer.set_transition_type(Gtk.RevealerTransitionType(0))
+        self.shell_escape_revealer.set_transition_type(Gtk.RevealerTransitionType.NONE)
         self.vbox1 = Gtk.VBox()
         label = Gtk.Label()
         label.set_markup('<b>' + _('Embedded system commands') + '</b>')

--- a/setzer/dialogs/preferences/pages/page_build_system.py
+++ b/setzer/dialogs/preferences/pages/page_build_system.py
@@ -130,7 +130,7 @@ class PageBuildSystemView(Gtk.VBox):
 
         label = Gtk.Label()
         label.set_line_wrap(True)
-        label.set_markup(_('Warning: if using Tectonic, make sure you do not require any shell escape features, as these are unsupported by the Tectonic command-line interface'))
+        label.set_markup(_('Warning: if using Tectonic, make sure you do not require any shell escape features, as these are unsupported by the Tectonic command-line interface. Note also that this uses the V1 Tectonic interface, so Tectonic.toml configuration files will NOT be respected.'))
         label.set_xalign(0)
         label.set_margin_bottom(9)
         label.get_style_context().add_class('description')

--- a/setzer/dialogs/preferences/pages/page_build_system.py
+++ b/setzer/dialogs/preferences/pages/page_build_system.py
@@ -171,6 +171,7 @@ class PageBuildSystemView(Gtk.VBox):
         self.pack_start(self.option_cleanup_build_files, False, False, 0)
 
         self.latexmk_enable_revealer = Gtk.Revealer()
+        self.latexmk_enable_revealer.set_transition_type(Gtk.RevealerTransitionType(0))
         self.option_use_latexmk = Gtk.CheckButton(_('Use Latexmk'))
         self.latexmk_enable_revealer.add(self.option_use_latexmk)
         self.pack_start(self.latexmk_enable_revealer, False, False, 0)
@@ -189,7 +190,7 @@ class PageBuildSystemView(Gtk.VBox):
         self.pack_start(self.option_autoshow_build_log_all, False, False, 0)
     
         self.shell_escape_revealer = Gtk.Revealer()
-
+        self.shell_escape_revealer.set_transition_type(Gtk.RevealerTransitionType(0))
         self.vbox1 = Gtk.VBox()
         label = Gtk.Label()
         label.set_markup('<b>' + _('Embedded system commands') + '</b>')

--- a/setzer/dialogs/preferences/pages/page_build_system.py
+++ b/setzer/dialogs/preferences/pages/page_build_system.py
@@ -55,7 +55,7 @@ class PageBuildSystem(object):
 
     def setup_latex_interpreters(self):
         self.latex_interpreters = list()
-        for interpreter in ['xelatex', 'pdflatex', 'lualatex']:
+        for interpreter in ['xelatex', 'pdflatex', 'lualatex', 'tectonic']:
             self.view.option_latex_interpreter[interpreter].hide()
             arguments = [interpreter, '--version']
             try:
@@ -98,7 +98,18 @@ class PageBuildSystem(object):
                 self.view.option_latex_interpreter[interpreter].set_active(interpreter == self.settings.get_value('preferences', 'latex_interpreter'))
             for interpreter in self.latex_interpreters:
                 self.view.option_latex_interpreter[interpreter].connect('toggled', self.preferences.on_interpreter_changed, 'latex_interpreter', interpreter)
+            
+            self.view.option_latex_interpreter['tectonic'].connect('toggled', self.on_use_tectonic_toggled)
+            self.view.latexmk_enable_revealer.set_reveal_child(not self.view.option_latex_interpreter['tectonic'].get_active())
+            self.view.shell_escape_revealer.set_reveal_child(not self.view.option_latex_interpreter['tectonic'].get_active())
 
+    def on_use_tectonic_toggled(self, button):
+        self.view.latexmk_enable_revealer.set_reveal_child(not button.get_active())
+        self.settings.set_value('preferences', 'use_latexmk', not button.get_active())
+
+        self.view.shell_escape_revealer.set_reveal_child(not button.get_active())
+        if (button.get_active()):
+            self.settings.set_value('preferences', 'build_option_system_commands', 'disable')
 
 class PageBuildSystemView(Gtk.VBox):
 
@@ -117,6 +128,15 @@ class PageBuildSystemView(Gtk.VBox):
         label.set_margin_bottom(6)
         self.pack_start(label, False, False, 0)
 
+        label = Gtk.Label()
+        label.set_line_wrap(True)
+        label.set_markup(_('Warning: if using Tectonic, make sure you do not require any shell escape features, as these are unsupported by the Tectonic command-line interface'))
+        label.set_xalign(0)
+        label.set_margin_bottom(9)
+        label.get_style_context().add_class('description')
+        self.pack_start(label, False, False, 0)
+
+
         self.no_interpreter_label = Gtk.Label()
         self.no_interpreter_label.set_line_wrap(True)
         self.no_interpreter_label.set_markup(_('No LaTeX interpreter found. For instructions on installing LaTeX see <a href="https://en.wikibooks.org/wiki/LaTeX/Installation">https://en.wikibooks.org/wiki/LaTeX/Installation</a>'))
@@ -131,11 +151,14 @@ class PageBuildSystemView(Gtk.VBox):
         self.option_latex_interpreter['pdflatex'].set_margin_right(12)
         self.option_latex_interpreter['lualatex'] = Gtk.RadioButton.new_with_label_from_widget(self.option_latex_interpreter['xelatex'], 'LuaLaTeX')
         self.option_latex_interpreter['lualatex'].set_margin_right(12)
+        self.option_latex_interpreter['tectonic'] = Gtk.RadioButton.new_with_label_from_widget(self.option_latex_interpreter['xelatex'], 'Tectonic')
+        self.option_latex_interpreter['tectonic'].set_margin_right(12)
 
         self.hbox1 = Gtk.HBox()
         self.hbox1.pack_start(self.option_latex_interpreter['xelatex'], False, False, 0)
         self.hbox1.pack_start(self.option_latex_interpreter['pdflatex'], False, False, 0)
         self.hbox1.pack_start(self.option_latex_interpreter['lualatex'], False, False, 0)
+        self.hbox1.pack_start(self.option_latex_interpreter['tectonic'], False, False, 0)
         self.pack_start(self.hbox1, False, False, 0)
 
         label = Gtk.Label()
@@ -146,8 +169,11 @@ class PageBuildSystemView(Gtk.VBox):
         self.pack_start(label, False, False, 0)
         self.option_cleanup_build_files = Gtk.CheckButton(_('Automatically remove helper files (.log, .dvi, ...) after building .pdf.'))
         self.pack_start(self.option_cleanup_build_files, False, False, 0)
+
+        self.latexmk_enable_revealer = Gtk.Revealer()
         self.option_use_latexmk = Gtk.CheckButton(_('Use Latexmk'))
-        self.pack_start(self.option_use_latexmk, False, False, 0)
+        self.latexmk_enable_revealer.add(self.option_use_latexmk)
+        self.pack_start(self.latexmk_enable_revealer, False, False, 0)
 
         label = Gtk.Label()
         label.set_markup('<b>' + _('Automatically show build log ..') + ' </b>')
@@ -162,24 +188,28 @@ class PageBuildSystemView(Gtk.VBox):
         self.pack_start(self.option_autoshow_build_log_errors_warnings, False, False, 0)
         self.pack_start(self.option_autoshow_build_log_all, False, False, 0)
     
+        self.shell_escape_revealer = Gtk.Revealer()
+
+        self.vbox1 = Gtk.VBox()
         label = Gtk.Label()
         label.set_markup('<b>' + _('Embedded system commands') + '</b>')
         label.set_xalign(0)
         label.set_margin_top(18)
         label.set_margin_bottom(6)
-        self.pack_start(label, False, False, 0)
+        self.vbox1.pack_start(label, False, False, 0)
         label = Gtk.Label()
         label.set_line_wrap(True)
         label.set_markup(_('Warning: enable this only if you have to. It can cause security problems when building files from untrusted sources.'))
         label.set_xalign(0)
         label.set_margin_bottom(9)
         label.get_style_context().add_class('description')
-        self.pack_start(label, False, False, 0)
+        self.vbox1.pack_start(label, False, False, 0)
         self.option_system_commands_disable = Gtk.RadioButton(_('Disable') + ' (' + _('recommended') + ')')
         self.option_system_commands_restricted = Gtk.RadioButton.new_with_label_from_widget(self.option_system_commands_disable, _('Enable restricted \\write18{SHELL COMMAND}'))
         self.option_system_commands_full = Gtk.RadioButton.new_with_label_from_widget(self.option_system_commands_disable, _('Fully enable \\write18{SHELL COMMAND}'))
-        self.pack_start(self.option_system_commands_disable, False, False, 0)
-        self.pack_start(self.option_system_commands_restricted, False, False, 0)
-        self.pack_start(self.option_system_commands_full, False, False, 0)
+        self.vbox1.pack_start(self.option_system_commands_disable, False, False, 0)
+        self.vbox1.pack_start(self.option_system_commands_restricted, False, False, 0)
+        self.vbox1.pack_start(self.option_system_commands_full, False, False, 0)
 
-
+        self.shell_escape_revealer.add(self.vbox1)
+        self.pack_start(self.shell_escape_revealer, False, False, 0)

--- a/setzer/document/build_system/build_system.py
+++ b/setzer/document/build_system/build_system.py
@@ -275,13 +275,16 @@ class BuildSystem(Observable):
             build_option_system_commands = self.settings.get_value('preferences', 'build_option_system_commands')
             additional_arguments = ''
 
-            lualatex_prefix = ' -' if interpreter == 'lualatex' else ' '
-            if build_option_system_commands == 'disable':
-                additional_arguments += lualatex_prefix + '-no-shell-escape'
-            elif build_option_system_commands == 'restricted':
-                additional_arguments += lualatex_prefix + '-shell-restricted'
-            elif build_option_system_commands == 'enable':
-                additional_arguments += lualatex_prefix + '-shell-escape'
+            if interpreter == 'tectonic':
+                pass
+            else:
+                lualatex_prefix = ' -' if interpreter == 'lualatex' else ' '
+                if build_option_system_commands == 'disable':
+                    additional_arguments += lualatex_prefix + '-no-shell-escape'
+                elif build_option_system_commands == 'restricted':
+                    additional_arguments += lualatex_prefix + '-shell-restricted'
+                elif build_option_system_commands == 'enable':
+                    additional_arguments += lualatex_prefix + '-shell-escape'
 
             text = self.document.content.get_all_text()
             do_cleanup = self.settings.get_value('preferences', 'cleanup_build_files')


### PR DESCRIPTION
This PR adds the tectonic latex interpreter. If using tectonic, the options for using latexmk and shell escape are hidden, as tectonic doesn't support either of these tools (and provides a similar functionality to latexmk). 

This uses the Tectonic V1 command-line interface, since the V2 interface is still under development and not yet stable. In the future, this could be updated to use the V2 interface instead (it relies on a toml configuration file much like latexmk uses a latexmkrc).

