### PR TITLE
bugfix included files

### DIFF
--- a/setzer/workspace/sidebar/document_structure_page/todos.py
+++ b/setzer/workspace/sidebar/document_structure_page/todos.py
@@ -56,7 +56,7 @@ class TodosSection(structure_widget.StructureWidget):
             todo.append(document)
             todos.append(todo)
         for document in self.data_provider.integrated_includes:
-            for todo in document.get_todo_with_offset():
+            for todo in document.get_todos_with_offset():
                 todo.append(document)
                 todos.append(todo)
         todos.sort(key=lambda todo: todo[0].lower())


### PR DESCRIPTION
had a small typo in the todos code that caused a bunch of weird behavior when updating document structure from included/imported files. This fixes that.