### PR TITLE
Move to `FileChooserNative`

### DIFF
--- a/setzer/dialogs/open_document/open_document.py
+++ b/setzer/dialogs/open_document/open_document.py
@@ -34,7 +34,7 @@ class OpenDocumentDialog(Dialog):
     def run(self):
         self.setup()
         response = self.view.run()
-        if response == Gtk.ResponseType.OK:
+        if response == Gtk.ResponseType.ACCEPT:
             return_value = self.view.get_filename()
         else:
             return_value = None
@@ -43,16 +43,7 @@ class OpenDocumentDialog(Dialog):
 
     def setup(self):
         self.action = Gtk.FileChooserAction.OPEN
-        self.buttons = (_('_Cancel'), Gtk.ResponseType.CANCEL, _('_Open'), Gtk.ResponseType.OK)
-        self.view = Gtk.FileChooserDialog(_('Open'), self.main_window, self.action, self.buttons)
-
-        headerbar = self.view.get_header_bar()
-        if headerbar != None:
-            for widget in headerbar.get_children():
-                if isinstance(widget, Gtk.Button) and widget.get_label() == _('_Open'):
-                    widget.get_style_context().add_class(Gtk.STYLE_CLASS_SUGGESTED_ACTION)
-                    widget.set_can_default(True)
-                    widget.grab_default()
+        self.view = Gtk.FileChooserNative.new(_('Open'), self.main_window, self.action, _('_Open'), _('_Cancel'))
 
         file_filter1 = Gtk.FileFilter()
         file_filter1.add_pattern('*.tex')

--- a/setzer/dialogs/open_session/open_session.py
+++ b/setzer/dialogs/open_session/open_session.py
@@ -34,7 +34,7 @@ class OpenSessionDialog(Dialog):
     def run(self):
         self.setup()
         response = self.view.run()
-        if response == Gtk.ResponseType.OK:
+        if response == Gtk.ResponseType.ACCEPT:
             return_value = self.view.get_filename()
         else:
             return_value = None
@@ -43,16 +43,7 @@ class OpenSessionDialog(Dialog):
 
     def setup(self):
         self.action = Gtk.FileChooserAction.OPEN
-        self.buttons = (_('_Cancel'), Gtk.ResponseType.CANCEL, _('_Open'), Gtk.ResponseType.OK)
-        self.view = Gtk.FileChooserDialog(_('Load Session'), self.main_window, self.action, self.buttons)
-
-        headerbar = self.view.get_header_bar()
-        if headerbar != None:
-            for widget in headerbar.get_children():
-                if isinstance(widget, Gtk.Button) and widget.get_label() == _('_Open'):
-                    widget.get_style_context().add_class(Gtk.STYLE_CLASS_SUGGESTED_ACTION)
-                    widget.set_can_default(True)
-                    widget.grab_default()
+        self.view = Gtk.FileChooserNative.new(_('Load Session'), self.main_window, self.action, _('_Open'), _('_Cancel'))
 
         file_filter1 = Gtk.FileFilter()
         file_filter1.add_pattern('*.stzs')

--- a/setzer/dialogs/preferences/pages/page_font_color.py
+++ b/setzer/dialogs/preferences/pages/page_font_color.py
@@ -353,7 +353,7 @@ class AddSchemeDialog(object):
     def run(self):
         self.setup()
         response = self.view.run()
-        if response == Gtk.ResponseType.OK:
+        if response == Gtk.ResponseType.ACCEPT:
             return_value = self.view.get_filename()
         else:
             return_value = None
@@ -363,16 +363,7 @@ class AddSchemeDialog(object):
 
     def setup(self):
         self.action = Gtk.FileChooserAction.OPEN
-        self.buttons = (_('_Cancel'), Gtk.ResponseType.CANCEL, _('_Add Scheme'), Gtk.ResponseType.OK)
-        self.view = Gtk.FileChooserDialog(_('Add Scheme'), self.main_window, self.action, self.buttons)
-
-        headerbar = self.view.get_header_bar()
-        if headerbar != None:
-            for widget in headerbar.get_children():
-                if isinstance(widget, Gtk.Button) and widget.get_label() == _('_Add Scheme'):
-                    widget.get_style_context().add_class(Gtk.STYLE_CLASS_SUGGESTED_ACTION)
-                    widget.set_can_default(True)
-                    widget.grab_default()
+        self.view = Gtk.FileChooserNative.new(_('Add Scheme'), self.main_window, self.action, _('_Add'), _('_Cancel'))
 
         file_filter1 = Gtk.FileFilter()
         file_filter1.add_pattern('*.xml')

--- a/setzer/dialogs/save_document/save_document.py
+++ b/setzer/dialogs/save_document/save_document.py
@@ -47,7 +47,7 @@ class SaveDocumentDialog(Dialog):
                 ending = ''
             self.view.set_current_name(ending)
         response = self.view.run()
-        if response == Gtk.ResponseType.OK:
+        if response == Gtk.ResponseType.ACCEPT:
             filename = self.view.get_filename()
             document.set_filename(filename)
             document.save_to_disk()
@@ -60,17 +60,7 @@ class SaveDocumentDialog(Dialog):
 
     def setup(self):
         self.action = Gtk.FileChooserAction.SAVE
-        self.buttons = (_('_Cancel'), Gtk.ResponseType.CANCEL, _('_Save'), Gtk.ResponseType.OK)
-        self.view = Gtk.FileChooserDialog(_('Save document'), self.main_window, self.action, self.buttons)
+        self.view = Gtk.FileChooserNative.new(_('Save document'), self.main_window, self.action, _('_Save'), _('_Cancel'))
 
         self.view.set_do_overwrite_confirmation(True)
-
-        headerbar = self.view.get_header_bar()
-        if headerbar != None:
-            for widget in headerbar.get_children():
-                if isinstance(widget, Gtk.Button) and widget.get_label() == _('_Save'):
-                    widget.get_style_context().add_class(Gtk.STYLE_CLASS_SUGGESTED_ACTION)
-                    widget.set_can_default(True)
-                    widget.grab_default()
-        
 

--- a/setzer/dialogs/save_session/save_session.py
+++ b/setzer/dialogs/save_session/save_session.py
@@ -49,7 +49,7 @@ class SaveSessionDialog(Dialog):
                 self.view.set_current_name('.stzs')
 
         response = self.view.run()
-        if response == Gtk.ResponseType.OK:
+        if response == Gtk.ResponseType.ACCEPT:
             filename = self.view.get_filename()
             self.workspace.save_session(filename)
             return_value = True
@@ -60,17 +60,7 @@ class SaveSessionDialog(Dialog):
 
     def setup(self):
         self.action = Gtk.FileChooserAction.SAVE
-        self.buttons = (_('_Cancel'), Gtk.ResponseType.CANCEL, _('_Save'), Gtk.ResponseType.OK)
-        self.view = Gtk.FileChooserDialog(_('Save Session'), self.main_window, self.action, self.buttons)
+        self.view = Gtk.FileChooserNative.new(_('Save Session'), self.main_window, self.action, _('_Save'), _('_Cancel'))
 
         self.view.set_do_overwrite_confirmation(True)
-
-        headerbar = self.view.get_header_bar()
-        if headerbar != None:
-            for widget in headerbar.get_children():
-                if isinstance(widget, Gtk.Button) and widget.get_label() == _('_Save'):
-                    widget.get_style_context().add_class(Gtk.STYLE_CLASS_SUGGESTED_ACTION)
-                    widget.set_can_default(True)
-                    widget.grab_default()
-        
 

--- a/setzer/widgets/filechooser_button/filechooser_button.py
+++ b/setzer/widgets/filechooser_button/filechooser_button.py
@@ -72,27 +72,19 @@ class FilechooserButton(Observable):
 
     def on_button_clicked(self, button):
         action = Gtk.FileChooserAction.OPEN
-        buttons = (_('_Cancel'), Gtk.ResponseType.CANCEL, _('_Select'), Gtk.ResponseType.APPLY)
-        dialog = Gtk.FileChooserDialog(self.title, self.main_window, action, buttons)
+        dialog = Gtk.FileChooserNative.new(self.title, self.main_window, action, _('_Select'), _('_Cancel'))
 
         for file_filter in self.filters:
             dialog.add_filter(file_filter)
-
-        for widget in dialog.get_header_bar().get_children():
-            if isinstance(widget, Gtk.Button) and widget.get_label() == _('_Select'):
-                widget.get_style_context().add_class(Gtk.STYLE_CLASS_SUGGESTED_ACTION)
-                widget.set_can_default(True)
-                widget.grab_default()
 
         if self.default_folder != None:
             dialog.set_current_folder(self.default_folder)
 
         response = dialog.run()
-        if response == Gtk.ResponseType.APPLY:
+        if response == Gtk.ResponseType.ACCEPT:
             self.filename = dialog.get_filename()
             self.view.button_label.set_text(os.path.basename(self.filename))
             self.add_change_code('file-set')
         dialog.hide()
         del(dialog)
-
 


### PR DESCRIPTION
Enables Flatpak users to see the dialog of their desktop environment.

Changes the responses to the ones in this dialog which are
REPONSE_ACCEPT and RESPONSE_CANCEL.

It also cleans up the code for the suggested action that is in the hands
of the platform. The GTK/GNOME file selector has open as the suggested
action, for example.