### PR TITLE
Make latexdb XML files translatable

### DIFF
--- a/po/README.md
+++ b/po/README.md
@@ -7,6 +7,7 @@ Run: (replace `lang` with the language code)
 rm -Rf builddir
 meson builddir --prefix=/tmp/usr
 ninja setzer-pot -C builddir
+xgettext data/resources/latexdb/*/*.xml -o po/setzer.pot --from-code=UTF-8 --join-existing --its=po/setzer.its
 cp po/setzer.pot po/lang.po
 ```
 Now translate the strings in `lang.po` and add `lang` to the `LINGUAS` file.
@@ -18,6 +19,8 @@ Run:
 rm -Rf builddir
 meson builddir --prefix=/tmp/usr
 ninja setzer-update-po -C builddir
+xgettext data/resources/latexdb/*/*.xml -o po/setzer.pot --from-code=UTF-8 --join-existing --its=po/setzer.its
+msgmerge -U po/lang.po po/setzer.pot
 ```
 Now translate the fuzzy strings in `lang.po` (remove the `#,fuzzy` lines).
 

--- a/po/setzer.its
+++ b/po/setzer.its
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<its:rules xmlns:its="http://www.w3.org/2005/11/its"
+           xmlns:gt="https://www.gnu.org/s/gettext/ns/its/extensions/1.0"
+           version="2.0">
+  <its:translateRule selector="//command/@description" translate="yes"/>
+  <its:translateRule selector="//package/@description" translate="yes"/>"
+</its:rules>

--- a/setzer/app/autocomplete_provider/autocomplete_provider.py
+++ b/setzer/app/autocomplete_provider/autocomplete_provider.py
@@ -400,7 +400,7 @@ class AutocompleteProvider(object):
             root = tree.getroot()
             for child in root:
                 attrib = child.attrib
-                commands[attrib['name']] = {'command': attrib['text'], 'description': attrib['description'], 'lowpriority': True if attrib['lowpriority'] == "True" else False, 'dotlabels': attrib['dotlabels']}
+                commands[attrib['name']] = {'command': attrib['text'], 'description': _(attrib['description']), 'lowpriority': True if attrib['lowpriority'] == "True" else False, 'dotlabels': attrib['dotlabels']}
                 match = re.match(r'\\begin\{([^\}]+)\}', attrib['name'])
                 if match:
                     name = match.group(1)

--- a/setzer/app/service_locator.py
+++ b/setzer/app/service_locator.py
@@ -127,7 +127,7 @@ class ServiceLocator(object):
             root = tree.getroot()
             for child in root:
                 attrib = child.attrib
-                ServiceLocator.packages_dict[attrib['name']] = {'command': attrib['text'], 'description': attrib['description']}
+                ServiceLocator.packages_dict[attrib['name']] = {'command': attrib['text'], 'description': _(attrib['description'])}
         return ServiceLocator.packages_dict
 
     def get_config_folder():


### PR DESCRIPTION
Uses ITS Tool which works for XML files and it is included in gettext.

Opening as a draft as I am not sure which attributes need to be translated.

Fixes #135