### PR TITLE
Remove perl as 5.36 is in the texlive SDK

### DIFF
--- a/org.cvfosammmm.Setzer.json
+++ b/org.cvfosammmm.Setzer.json
@@ -90,41 +90,6 @@
             ]
         },
         {
-            "name": "perl",
-            "no-autogen": true,
-            "config-opts": [
-                "-des",
-                "-Duseshrplib"
-            ],
-            "build-options": {
-                "cflags": "-fPIC",
-                "ldflags": "-fpic",
-                "no-debuginfo": true
-            },
-            "cleanup": [
-                "/man",
-                "*.pod",
-                "*.h"
-            ],
-            "ensure-writable": [
-                "/lib/perl5/5.36.0"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://www.cpan.org/src/5.0/perl-5.36.0.tar.gz",
-                    "sha256": "e26085af8ac396f62add8a533c3a0ea8c8497d836f0689347ac5abd7b7a4e00a"
-                },
-                {
-                    "type": "script",
-                    "dest-filename": "configure",
-                    "commands": [
-                        "exec ./configure.gnu $@"
-                    ]
-                }
-            ]
-        },
-        {
             "name": "python3-pexpect",
             "buildsystem": "simple",
             "build-commands": [


### PR DESCRIPTION
See [org.freedesktop.Sdk.Extension.texlive manifest](https://github.com/flathub/org.freedesktop.Sdk.Extension.texlive/blob/7588b2a7aea49ad8dcbb1fe0fdce6eb9ba4f3085/org.freedesktop.Sdk.Extension.texlive.yml#L72)