### PR TITLE
Add language chooser to LaTeX document wizard

### DIFF
--- a/data/resources/document_wizard/languages.xml
+++ b/data/resources/document_wizard/languages.xml
@@ -1,0 +1,57 @@
+<languages>
+    <language code="english" name="English"/>
+    <language code="spanish" name="Spanish"/>
+    <language code="french" name="French"/>
+    <language code="russian" name="Russian"/>
+    <language code="brazilian" name="Portuguese"/>
+    <language code="portuguese" name="Portuguese"/>
+    <language code="ngerman" name="German"/>
+    <language code="italian" name="Italian"/>
+    <language code="afrikaans" name="Afrikaans"/>
+    <language code="azerbaijani" name="Azerbaijani"/>
+    <language code="basque" name="Basque"/>
+    <language code="breton" name="Breton"/>
+    <language code="bulgarian" name="Bulgarian"/>
+    <language code="catalan" name="Catalan"/>
+    <language code="croatian" name="Croatian"/>
+    <language code="czech" name="Czech"/>
+    <language code="danish" name="Danish"/>
+    <language code="dutch" name="Dutch"/>
+    <language code="american" name="English"/>
+    <language code="british" name="English"/>
+    <language code="canadian" name="English"/>
+    <language code="australian" name="English"/>
+    <language code="newzealand" name="English"/>
+    <language code="esperanto" name="Esperanto"/>
+    <language code="estonian" name="Estonian"/>
+    <language code="finnish" name="Finnish"/>
+    <language code="acadian" name="French"/>
+    <language code="galician" name="Galician"/>
+    <language code="naustrian" name="German"/>
+    <language code="german" name="German"/>
+    <language code="austrian" name="German"/>
+    <language code="greek" name="Greek"/>
+    <language code="polutonikogreek" name="Greek"/>
+    <language code="hebrew" name="Hebrew"/>
+    <language code="icelandic" name="Icelandic"/>
+    <language code="indonesian" name="Indonesian"/>
+    <language code="interlingua" name="Interlingua"/>
+    <language code="irish" name="Irish Gaelic"/>
+    <language code="latin" name="Latin"/>
+    <language code="lowersorbian" name="Lower Sorbian"/>
+    <language code="malay" name="Malay"/>
+    <language code="northernsami" name="Northern Sami"/>
+    <language code="norsk" name="Norwegian"/>
+    <language code="nynorsk" name="Norwegian"/>
+    <language code="polish" name="Polish"/>
+    <language code="romanian" name="Romanian"/>
+    <language code="scottishgaelic" name="Scottish Gaelic"/>
+    <language code="slovak" name="Slovakian"/>
+    <language code="slovene" name="Slovenian"/>
+    <language code="swedish" name="Swedish"/>
+    <language code="serbian" name="Serbian"/>
+    <language code="turkish" name="Turkish"/>
+    <language code="ukrainian" name="Ukrainian"/>
+    <language code="uppersorbian" name="Upper Sorbian"/>
+    <language code="welsh" name="Welsh"/>
+</languages>

--- a/po/README.md
+++ b/po/README.md
@@ -7,7 +7,7 @@ Run: (replace `lang` with the language code)
 rm -Rf builddir
 meson builddir --prefix=/tmp/usr
 ninja setzer-pot -C builddir
-xgettext data/resources/latexdb/*/*.xml -o po/setzer.pot --from-code=UTF-8 --join-existing --its=po/setzer.its
+xgettext data/resources/latexdb/*/*.xml data/resources/document_wizard/languages.xml -o po/setzer.pot --from-code=UTF-8 --join-existing --its=po/setzer.its
 cp po/setzer.pot po/lang.po
 ```
 Now translate the strings in `lang.po` and add `lang` to the `LINGUAS` file.
@@ -19,7 +19,7 @@ Run:
 rm -Rf builddir
 meson builddir --prefix=/tmp/usr
 ninja setzer-update-po -C builddir
-xgettext data/resources/latexdb/*/*.xml -o po/setzer.pot --from-code=UTF-8 --join-existing --its=po/setzer.its
+xgettext data/resources/latexdb/*/*.xml data/resources/document_wizard/languages.xml -o po/setzer.pot --from-code=UTF-8 --join-existing --its=po/setzer.its
 msgmerge -U po/lang.po po/setzer.pot
 ```
 Now translate the fuzzy strings in `lang.po` (remove the `#,fuzzy` lines).

--- a/po/setzer.its
+++ b/po/setzer.its
@@ -3,5 +3,6 @@
            xmlns:gt="https://www.gnu.org/s/gettext/ns/its/extensions/1.0"
            version="2.0">
   <its:translateRule selector="//command/@description" translate="yes"/>
-  <its:translateRule selector="//package/@description" translate="yes"/>"
+  <its:translateRule selector="//package/@description" translate="yes"/>
+  <its:translateRule selector="//language/@name" translate="yes"/>
 </its:rules>

--- a/setzer/app/service_locator.py
+++ b/setzer/app/service_locator.py
@@ -42,6 +42,7 @@ class ServiceLocator(object):
     regexes = dict()
     popover_menu_builder = None
     autocomplete_provider = None
+    languages_dict = None
     packages_dict = None
     source_language_manager = None
     source_style_scheme_manager = None
@@ -117,6 +118,19 @@ class ServiceLocator(object):
 
     def get_autocomplete_provider():
         return ServiceLocator.autocomplete_provider
+
+    def get_languages_dict():
+        if ServiceLocator.languages_dict == None:
+            ServiceLocator.languages_dict = dict()
+
+            resources_path = ServiceLocator.get_resources_path()
+            tree = ET.parse(os.path.join(resources_path, 'document_wizard', 'languages.xml'))
+            root = tree.getroot()
+            for child in root:
+                attrib = child.attrib
+                ServiceLocator.languages_dict[attrib['code']] = _(attrib['name'])
+
+        return ServiceLocator.languages_dict
 
     def get_packages_dict():
         if ServiceLocator.packages_dict == None:

--- a/setzer/dialogs/document_wizard/document_wizard.py
+++ b/setzer/dialogs/document_wizard/document_wizard.py
@@ -90,6 +90,7 @@ class DocumentWizard(Dialog):
         self.current_values['title'] = ''
         self.current_values['author'] = ''
         self.current_values['date'] = '\\today'
+        self.current_values['languages'] = ServiceLocator.get_languages_dict()
         self.current_values['packages'] = dict()
         self.current_values['packages']['ams'] = True
         self.current_values['packages']['graphicx'] = True
@@ -225,6 +226,7 @@ class DocumentWizard(Dialog):
 ('''\\usepackage[top=''' + str(self.current_values['article']['margin_top']) + '''cm, bottom=''' + str(self.current_values['article']['margin_bottom']) + '''cm, left=''' + str(self.current_values['article']['margin_left']) + '''cm, right=''' + str(self.current_values['article']['margin_right']) + '''cm]{geometry}''' if not self.current_values['article']['option_default_margins'] else '')
 + '''\\usepackage[T1]{fontenc}
 \\usepackage[utf8]{inputenc}
+\\usepackage[''' + next(iter(self.current_values['languages'])) + ''']{babel}
 \\usepackage{lmodern}
 ''' + self.get_insert_packages() + '''
 \\title{''' + self.current_values['title'] + '''}
@@ -251,6 +253,7 @@ class DocumentWizard(Dialog):
 ('''\\usepackage[top=''' + str(self.current_values['report']['margin_top']) + '''cm, bottom=''' + str(self.current_values['report']['margin_bottom']) + '''cm, left=''' + str(self.current_values['report']['margin_left']) + '''cm, right=''' + str(self.current_values['report']['margin_right']) + '''cm]{geometry}''' if not self.current_values['report']['option_default_margins'] else '')
 + '''\\usepackage[T1]{fontenc}
 \\usepackage[utf8]{inputenc}
+\\usepackage[''' + next(iter(self.current_values['languages'])) + ''']{babel}
 \\usepackage{lmodern}
 ''' + self.get_insert_packages() + '''
 \\title{''' + self.current_values['title'] + '''}
@@ -277,6 +280,7 @@ class DocumentWizard(Dialog):
 ('''\\usepackage[top=''' + str(self.current_values['book']['margin_top']) + '''cm, bottom=''' + str(self.current_values['book']['margin_bottom']) + '''cm, left=''' + str(self.current_values['book']['margin_left']) + '''cm, right=''' + str(self.current_values['book']['margin_right']) + '''cm]{geometry}''' if not self.current_values['book']['option_default_margins'] else '')
 + '''\\usepackage[T1]{fontenc}
 \\usepackage[utf8]{inputenc}
+\\usepackage[''' + next(iter(self.current_values['languages'])) + ''']{babel}
 \\usepackage{lmodern}
 ''' + self.get_insert_packages() + '''
 \\title{''' + self.current_values['title'] + '''}
@@ -300,6 +304,7 @@ class DocumentWizard(Dialog):
 ('''\\usepackage[top=''' + str(self.current_values['letter']['margin_top']) + '''cm, bottom=''' + str(self.current_values['letter']['margin_bottom']) + '''cm, left=''' + str(self.current_values['letter']['margin_left']) + '''cm, right=''' + str(self.current_values['letter']['margin_right']) + '''cm]{geometry}''' if not self.current_values['letter']['option_default_margins'] else '')
 + '''\\usepackage[T1]{fontenc}
 \\usepackage[utf8]{inputenc}
+\\usepackage[''' + next(iter(self.current_values['languages'])) + ''']{babel}
 \\usepackage{lmodern}
 ''' + self.get_insert_packages() + '''
 \\address{Your name\\\\Your address\\\\Your phone number}
@@ -333,6 +338,7 @@ class DocumentWizard(Dialog):
         return ('''\\documentclass''' + top_align + '''{beamer}
 \\usepackage[T1]{fontenc}
 \\usepackage[utf8]{inputenc}
+\\usepackage[''' + next(iter(self.current_values['languages'])) + ''']{babel}
 \\usepackage{lmodern}
 ''' + self.get_insert_packages() + '''\\usetheme{''' + theme + '''}''' + show_navigation + '''
 


### PR DESCRIPTION
List of languages from [Babel User guide](https://github.com/latex3/babel/blob/d01bca5a8bc876a2b9c03337751f2fac09808ccf/babel.pdf), section 1.27.

There are more languages available, but according to the user guide:

> Most of them work out of the box, but some may require extra fonts, encoding files, a
preprocessor or even a complete framework (like CJK or luatexja).

- [x] https://github.com/cvfosammmm/Setzer/issues/171#issuecomment-1571900164
- [x] Show language name instead of its code.

Fixes #171

![imagen](https://github.com/cvfosammmm/Setzer/assets/42654671/cf2de57e-3299-4356-b37b-4538e70558c5)