### PR TITLE
Use ellipsis character instead of three dots

### DIFF
--- a/data/resources/latexdb/packages/general.xml
+++ b/data/resources/latexdb/packages/general.xml
@@ -20,7 +20,7 @@
   <package name="parskip" text="parskip" description="paragraphs without indentation." />
   <package name="pgfplots" text="pgfplots" description="create plots in two and three dimensions." />
   <package name="textcomp" text="textcomp" description="contains symbols to be used in textmode." />
-  <package name="theorem" text="theorem" description="define theorem environments (like &quot;definition&quot;, &quot;lemma&quot;, ...) with custom styling." />
+  <package name="theorem" text="theorem" description="define theorem environments (like &quot;definition&quot;, &quot;lemma&quot;, …) with custom styling." />
   <package name="tikz" text="tikz" description="graphics and plotting." />
   <package name="transparent" text="transparent" description="set transparency for sections in your document." />
   <package name="url" text="url" description="type urls with the \\url{..} command without escaping them." />

--- a/po/setzer.pot
+++ b/po/setzer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-13 18:30+0200\n"
+"POT-Creation-Date: 2023-06-14 15:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -848,7 +848,7 @@ msgstr ""
 #: setzer/dialogs/document_wizard/pages/page_document_class.py:82
 msgid ""
 "<b>Article:</b>  For articles in scientific journals, term papers, handouts, "
-"short reports, ...\n"
+"short reports, …\n"
 "\n"
 "This class on its own is pretty simplistic and is often used as a starting "
 "point for more custom layouts."
@@ -876,7 +876,7 @@ msgid ""
 msgstr ""
 
 #: setzer/dialogs/document_wizard/pages/page_general_settings.py:116
-msgid "Others..."
+msgid "Others…"
 msgstr ""
 
 #: setzer/dialogs/document_wizard/pages/page_general_settings.py:136
@@ -920,7 +920,7 @@ msgstr ""
 #: setzer/dialogs/document_wizard/pages/page_general_settings.py:225
 msgid ""
 "<b>AMS packages:</b> provide mathematical symbols, math-related "
-"environments, ..."
+"environments, …"
 msgstr ""
 
 #: setzer/dialogs/document_wizard/pages/page_general_settings.py:225
@@ -964,8 +964,8 @@ msgstr ""
 
 #: setzer/dialogs/document_wizard/pages/page_general_settings.py:232
 msgid ""
-"define theorem environments (like \"definition\", \"lemma\", ...) with "
-"custom styling."
+"define theorem environments (like \"definition\", \"lemma\", …) with custom "
+"styling."
 msgstr ""
 
 #: setzer/dialogs/document_wizard/pages/page_general_settings.py:233
@@ -1451,8 +1451,7 @@ msgid ""
 msgstr ""
 
 #: setzer/dialogs/preferences/pages/page_build_system.py:178
-msgid ""
-"Automatically remove helper files (.log, .dvi, ...) after building .pdf."
+msgid "Automatically remove helper files (.log, .dvi, …) after building .pdf."
 msgstr ""
 
 #: setzer/dialogs/preferences/pages/page_build_system.py:183
@@ -1587,7 +1586,7 @@ msgid "Remove active scheme"
 msgstr ""
 
 #: setzer/dialogs/preferences/pages/page_font_color.py:312
-msgid "Add from file..."
+msgid "Add from file…"
 msgstr ""
 
 #: setzer/dialogs/preferences/pages/page_font_color.py:317
@@ -2656,8 +2655,8 @@ msgstr ""
 
 #: data/resources/latexdb/packages/general.xml:23
 msgid ""
-"define theorem environments (like &quot;definition&quot;, &quot;"
-"lemma&quot;, ...) with custom styling."
+"define theorem environments (like &quot;definition&quot;, &quot;lemma&quot;, "
+"…) with custom styling."
 msgstr ""
 
 #: data/resources/latexdb/packages/general.xml:24

--- a/setzer/dialogs/document_wizard/pages/page_document_class.py
+++ b/setzer/dialogs/document_wizard/pages/page_document_class.py
@@ -79,7 +79,7 @@ class DocumentClassPageView(PageView):
         self.preview_container = Gtk.Stack()
         self.preview_container.set_size_request(366, -1)
         self.preview_data = list()
-        self.preview_data.append({'name': 'article', 'image': 'article1.svg', 'text': _('<b>Article:</b>  For articles in scientific journals, term papers, handouts, short reports, ...\n\nThis class on its own is pretty simplistic and is often used as a starting point for more custom layouts.')})
+        self.preview_data.append({'name': 'article', 'image': 'article1.svg', 'text': _('<b>Article:</b>  For articles in scientific journals, term papers, handouts, short reports, …\n\nThis class on its own is pretty simplistic and is often used as a starting point for more custom layouts.')})
         self.preview_data.append({'name': 'book', 'image': 'book1.svg', 'text': _('<b>Book:</b>  For actual books containing many chapters and sections.')})
         self.preview_data.append({'name': 'report', 'image': 'report1.svg', 'text': _('<b>Report:</b>  For longer reports and articles containing more than one chapter, small books, thesis.')})
         self.preview_data.append({'name': 'letter', 'image': 'letter1.svg', 'text': _('<b>Letter:</b>  For writing letters.')})

--- a/setzer/dialogs/document_wizard/pages/page_general_settings.py
+++ b/setzer/dialogs/document_wizard/pages/page_general_settings.py
@@ -113,7 +113,7 @@ class GeneralSettingsPage(Page):
                 self.view.language_buttons[index].set_label(label)
             else:
                 self.view.language_combobox.append(code, label)
-        self.view.language_combobox.prepend_text(_('Others...'))
+        self.view.language_combobox.prepend_text(_('Others…'))
         self.view.language_combobox.set_active(0)
         self.view.language_buttons[0].set_active(True)
 
@@ -222,14 +222,14 @@ class GeneralSettingsPageView(PageView):
         
         self.packages_tooltip = Gtk.Label()
         self.packages_tooltip_data = dict()
-        self.packages_tooltip_data['ams'] = _('<b>AMS packages:</b> provide mathematical symbols, math-related environments, ...') + ' (' + _('recommended') + ')'
+        self.packages_tooltip_data['ams'] = _('<b>AMS packages:</b> provide mathematical symbols, math-related environments, …') + ' (' + _('recommended') + ')'
         self.packages_tooltip_data['textcomp'] = '<b>textcomp:</b> ' + _('contains symbols to be used in textmode.') + ' (' + _('recommended') + ')'
         self.packages_tooltip_data['graphicx'] = '<b>graphicx:</b> ' + _('include graphics in your document.') + ' (' + _('recommended') + ')'
         self.packages_tooltip_data['color'] = '<b>color:</b> ' + _('foreground and background color.') + ' (' + _('recommended') + ')'
         self.packages_tooltip_data['xcolor'] = '<b>xcolor:</b> ' + _('enables colored text.') + ' (' + _('recommended') + ')'
         self.packages_tooltip_data['url'] = '<b>url:</b> ' + _('type urls with the \\url{..} command without escaping them.') + ' (' + _('recommended') + ')'
         self.packages_tooltip_data['hyperref'] = '<b>hyperref:</b> ' + _('create hyperlinks within your document.')
-        self.packages_tooltip_data['theorem'] = '<b>theorem:</b> ' + _('define theorem environments (like "definition", "lemma", ...) with custom styling.')
+        self.packages_tooltip_data['theorem'] = '<b>theorem:</b> ' + _('define theorem environments (like "definition", "lemma", …) with custom styling.')
         self.packages_tooltip_data['listings'] = '<b>listings:</b> ' + _('provides the \\listing environment for embedding programming code.')
         self.packages_tooltip_data['glossaries'] = '<b>glossaries:</b> ' + _('create a glossary for your document.')
         self.packages_tooltip_data['parskip'] = '<b>parskip:</b> ' + _('paragraphs without indentation.')

--- a/setzer/dialogs/preferences/pages/page_build_system.py
+++ b/setzer/dialogs/preferences/pages/page_build_system.py
@@ -175,7 +175,7 @@ class PageBuildSystemView(Gtk.VBox):
         label.set_margin_top(18)
         label.set_margin_bottom(6)
         self.pack_start(label, False, False, 0)
-        self.option_cleanup_build_files = Gtk.CheckButton(_('Automatically remove helper files (.log, .dvi, ...) after building .pdf.'))
+        self.option_cleanup_build_files = Gtk.CheckButton(_('Automatically remove helper files (.log, .dvi, …) after building .pdf.'))
         self.pack_start(self.option_cleanup_build_files, False, False, 0)
 
         self.latexmk_enable_revealer = Gtk.Revealer()

--- a/setzer/dialogs/preferences/pages/page_font_color.py
+++ b/setzer/dialogs/preferences/pages/page_font_color.py
@@ -309,7 +309,7 @@ class PageFontColorView(Gtk.ScrolledWindow):
         self.remove_scheme_button.set_label(_('Remove active scheme'))
         box.pack_end(self.remove_scheme_button, False, False, 0)
         self.add_scheme_button = Gtk.Button()
-        self.add_scheme_button.set_label(_('Add from file...'))
+        self.add_scheme_button.set_label(_('Add from file…'))
         box.pack_start(self.add_scheme_button, False, False, 0)
         self.box.pack_start(box, False, False, 0)
 


### PR DESCRIPTION
Follows https://developer.gnome.org/hig/guidelines/writing-style.html and fixes some failing checks in Weblate.

It's also useful to test that add-ons in Weblate work well and that the repository hook works as well. Before merging, Weblate should be unlocked temporarily (Manage > Repository maintenance).