### PR TITLE
Fix for Saving on Close Confirmation

### DIFF
--- a/setzer/dialogs/close_confirmation/close_confirmation.py
+++ b/setzer/dialogs/close_confirmation/close_confirmation.py
@@ -56,7 +56,8 @@ class CloseConfirmationDialog(object):
             if len(documents) == 1:
                 selected_documents.append(documents[0])
             else:
-                for child in self.chooser.get_children():
+                for i in range(0, len(documents) - 1):
+                    child = self.chooser.get_row_at_index(i)
                     if child.get_child().get_active():
                         number = int(child.get_child().get_name()[29:])
                         selected_documents.append(documents[number])

--- a/setzer/dialogs/close_confirmation/close_confirmation.py
+++ b/setzer/dialogs/close_confirmation/close_confirmation.py
@@ -56,7 +56,7 @@ class CloseConfirmationDialog(object):
             if len(documents) == 1:
                 selected_documents.append(documents[0])
             else:
-                for i in range(0, len(documents) - 1):
+                for i in range(0, len(documents)):
                     child = self.chooser.get_row_at_index(i)
                     if child.get_child().get_active():
                         number = int(child.get_child().get_name()[29:])


### PR DESCRIPTION
When there are multiple unsaved changes across files, CloseConfirmationDialog will present a list of files that need saving. This list is a GtkListBox. The problem is that, to get all row entries, the method get_children was used, which does not exist. The save operation will fail. Apparently this bug has been sitting here for quite some times.

Fix is to manually retrieve each row entry with get_row_at_index.