### PR TITLE
Show appname as process title

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,11 +4,14 @@ project(
   license: 'GPL-3.0-or-later',
 )
 
+python = import('python').find_installation()
+python_bin = python.full_path()
+
 # configure folders
 prefix = get_option('prefix')
 bindir = get_option('bindir')
 datadir = get_option('datadir')
-pymdir = import('python').find_installation().get_install_dir()
+pymdir = python.get_install_dir()
 resourcesdir = join_paths(datadir, 'Setzer')
 localedir = get_option('localedir')
 mandir = get_option('mandir')
@@ -18,6 +21,7 @@ config.set('setzer_version', meson.project_version())
 config.set('localedir_path', join_paths(prefix, localedir))
 config.set('resources_path', join_paths(prefix, resourcesdir, 'resources'))
 config.set('app_icons_path', join_paths(prefix, datadir, 'icons'))
+config.set('python_path', python_bin)
 
 config_dev = config
 config_dev.set('localedir_path', '/tmp/usr/share/locale') # this is a workaround

--- a/setzer.in
+++ b/setzer.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!@python_path@
 # coding: utf-8
 
 # Copyright (C) 2017-present Robert Griesel


### PR DESCRIPTION
Solve #371 

It seems that running the setzer executable with `/usr/bin/env python3` as shebang will alter the process name to be python3. On the other hand, using full path to the python interpreter will force script name (setzer) as process name. As a bonus, application icon will also appear in System Monitor.

Before:

![image](https://github.com/cvfosammmm/Setzer/assets/55516702/e2d9e1a3-3b22-49e0-9b83-a6d93510792d)

After:

![image](https://github.com/cvfosammmm/Setzer/assets/55516702/d4d8d37a-a4ab-46c0-85fe-bb2746532b39)

I'm not sure if there's an explanation for env's behavior. Taken from [this Stack Overflow answer](https://stackoverflow.com/questions/2255444/changing-the-process-name-of-a-python-script/25338292#25338292).

This is also what the PyGTK app GNOME Secrets did in order to get appname shown in System Monitor. The devs used full path to Python interpreter in the executable's shebang.

A consequence of this is that, since we're moving away from env, the interpreter path is determined only at build time. In theory, if this path is changed post-installation then the program must be rebuilt. I tested on my machine and the meson command that returns the interpreter path, `import('python').find_installation().full_path()`, returned `/usr/bin/python3`, which should default to any python 3 interpreter. So in reality this is stable enough, so I think this should be no problem.
