### PR TITLE
Appdata related changes

### DIFF
--- a/data/org.cvfosammmm.Setzer.metainfo.xml.in
+++ b/data/org.cvfosammmm.Setzer.metainfo.xml.in
@@ -4,9 +4,9 @@
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0-or-later</project_license>
     <content_rating type="oars-1.1" />
-    <name translatable="no">Setzer</name>
+    <name translate="no">Setzer</name>
     <summary>Simple yet full-featured LaTeX editor</summary>
-    <developer_name translatable="no">Cvfosammmm</developer_name>
+    <developer_name translate="no">Cvfosammmm</developer_name>
 
     <description>
         <p>Setzer lets you Write LaTeX documents with an easy to use yet full-featured editor.</p>
@@ -65,292 +65,292 @@
 
     <releases>
         <release version="65" date="2023-12-14">
-            <description translatable="no">
+            <description translate="no">
                 <p>Fix brackets autoclosing, add brackets to selected text (instead of replacing it), ...</p>
             </description>
         </release>
         <release version="64" date="2023-12-11">
-            <description translatable="no">
+            <description translate="no">
                 <p>Autocomplete preferences, ...</p>
             </description>
         </release>
         <release version="63" date="2023-12-4">
-            <description translatable="no">
+            <description translate="no">
                 <p>Navigate popovers with keyboard, ...</p>
             </description>
         </release>
         <release version="62" date="2023-11-21">
-            <description translatable="no">
+            <description translate="no">
                 <p>Custom popovers, ...</p>
             </description>
         </release>
         <release version="61" date="2023-10-23">
-            <description translatable="no">
+            <description translate="no">
                 <p>Show app's name in system monitor, ...</p>
             </description>
         </release>
         <release version="60" date="2023-9-21">
-            <description translatable="no">
+            <description translate="no">
                 <p>Themes and recoloring, ...</p>
             </description>
         </release>
         <release version="59" date="2023-9-9">
-            <description translatable="no">
+            <description translate="no">
                 <p>Bug fix</p>
             </description>
         </release>
         <release version="58" date="2023-9-9">
-            <description translatable="no">
+            <description translate="no">
                 <p>Force light mode, ...</p>
             </description>
         </release>
         <release version="57" date="2023-8-29">
-            <description translatable="no">
+            <description translate="no">
                 <p>Gtk4, ...</p>
             </description>
         </release>
         <release version="56" date="2023-6-11">
-            <description translatable="no">
+            <description translate="no">
                 <p>Language chooser in document wizard, ...</p>
             </description>
         </release>
         <release version="55" date="2023-4-8">
-            <description translatable="no">
+            <description translate="no">
                 <p>Better dark / light mode support, ...</p>
             </description>
         </release>
         <release version="54" date="2023-3-10">
-            <description translatable="no">
+            <description translate="no">
                 <p>Tectonic support, parser improvements, todo items in the sidebar, show link targets in .pdf-preview, change version numbering ...</p>
             </description>
         </release>
         <release version="0.4.8" date="2022-7-28">
-            <description translatable="no">
+            <description translate="no">
                 <p>Bug fix</p>
             </description>
         </release>
         <release version="0.4.7" date="2022-3-25">
-            <description translatable="no">
+            <description translate="no">
                 <p>Jump over some brackets with tab, ...</p>
             </description>
         </release>
         <release version="0.4.6" date="2022-3-8">
-            <description translatable="no">
+            <description translate="no">
                 <p>Document stats in the sidebar, ...</p>
             </description>
         </release>
         <release version="0.4.5" date="2022-2-24">
-            <description translatable="no">
+            <description translate="no">
                 <p>Document structure widget in the sidebar, ...</p>
             </description>
         </release>
         <release version="0.4.4" date="2022-2-16">
-            <description translatable="no">
+            <description translate="no">
                 <p>Redesigned symbols sidebar with search and recent symbols, ...</p>
             </description>
         </release>
         <release version="0.4.3" date="2022-2-10">
-            <description translatable="no">
+            <description translate="no">
                 <p>Forward synctex from included files, code folding hover effect, ...</p>
             </description>
         </release>
         <release version="0.4.2" date="2021-11-21">
-            <description translatable="no">
+            <description translate="no">
                 <p>Performance improvements, persistent zoom in preview, ...</p>
             </description>
         </release>
         <release version="0.4.1" date="2021-1-19">
-            <description translatable="no">
+            <description translate="no">
                 <p>Bug fix</p>
             </description>
         </release>
         <release version="0.4.0" date="2021-1-16">
-            <description translatable="no">
+            <description translate="no">
                 <p>Performance improvements, ...</p>
             </description>
         </release>
         <release version="0.3.9" date="2021-1-2">
-            <description translatable="no">
+            <description translate="no">
                 <p>Support for links in .pdf preview, new welcome screen, ...</p>
             </description>
         </release>
         <release version="0.3.8" date="2020-12-12">
-            <description translatable="no">
+            <description translate="no">
                 <p>Build button now does save and build, performance improvements, ...</p>
             </description>
         </release>
         <release version="0.3.7" date="2020-11-28">
-            <description translatable="no">
+            <description translate="no">
                 <p>Performance improvements, ...</p>
             </description>
         </release>
         <release version="0.3.6" date="2020-11-8">
-            <description translatable="no">
+            <description translate="no">
                 <p>Save and build on F5, build in the directory of the LaTeX document being built, .cls and .sty file editing, ...</p>
             </description>
         </release>
         <release version="0.3.5" date="2020-10-28">
-            <description translatable="no">
+            <description translate="no">
                 <p>Zoom in editor view, show warning when document was deleted on disk, ...</p>
             </description>
         </release>
         <release version="0.3.4" date="2020-10-15">
-            <description translatable="no">
+            <description translate="no">
                 <p>Set editor font, context menu in shortcuts bar, ...</p>
             </description>
         </release>
         <release version="0.3.3" date="2020-10-6">
-            <description translatable="no">
+            <description translate="no">
                 <p>Add syntax themes from files, edit begin and end commands simultaneously, autocomplete improvements, ...</p>
             </description>
         </release>
         <release version="0.3.2" date="2020-9-9">
-            <description translatable="no">
+            <description translate="no">
                 <p>New syntax highlighting theme, full line indentation, ...</p>
             </description>
         </release>
         <release version="0.3.1" date="2020-9-1">
-            <description translatable="no">
+            <description translate="no">
                 <p>Tab autocomplete, dynamic citations autocomplete, more autocomplete improvements, ...</p>
             </description>
         </release>
         <release version="0.3.0" date="2020-8-20">
-            <description translatable="no">
+            <description translate="no">
                 <p>Biber support, Glossaries support, ...</p>
             </description>
         </release>
         <release version="0.2.9" date="2020-8-12">
-            <description translatable="no">
+            <description translate="no">
                 <p>Use Latexmk with any LaTeX interpreter, invert colors in .pdf preview, ...</p>
             </description>
         </release>
         <release version="0.2.8" date="2020-5-27">
-            <description translatable="no">
+            <description translate="no">
                 <p>Redesigned help panel homepage, LaTeX package documentation links, ...</p>
             </description>
         </release>
         <release version="0.2.7" date="2020-5-24">
-            <description translatable="no">
+            <description translate="no">
                 <p>Italian translation, help panel with LaTeX documentation, open files from the file manager and command line, ...</p>
             </description>
         </release>
         <release version="0.2.6" date="2020-5-11">
-            <description translatable="no">
+            <description translate="no">
                 <p>German translation, external .pdf viewer button, ...</p>
             </description>
         </release>
         <release version="0.2.5" date="2020-4-28">
-            <description translatable="no">
+            <description translate="no">
                 <p>Bug fix</p>
             </description>
         </release>
         <release version="0.2.4" date="2020-4-27">
-            <description translatable="no">
+            <description translate="no">
                 <p>Initial backward synctex support, improved synctex highlighting, search UI improvements, ...</p>
             </description>
         </release>
         <release version="0.2.3" date="2020-4-11">
-            <description translatable="no">
+            <description translate="no">
                 <p>Session management, highlight passages on build, ...</p>
             </description>
         </release>
         <release version="0.2.2" date="2020-4-2">
-            <description translatable="no">
+            <description translate="no">
                 <p>Zoom level popover for the .pdf preview, preview should use far less memory now, ...</p>
             </description>
         </release>
         <release version="0.2.1" date="2020-3-19">
-            <description translatable="no">
+            <description translate="no">
                 <p>Bug fixes</p>
             </description>
         </release>
         <release version="0.2.0" date="2020-3-18">
-            <description translatable="no">
+            <description translate="no">
                 <p>Enable embedded system commands, document modified on disk dialog, option to highlight current line, option to highlight matching brackets, ...</p>
             </description>
         </release>
         <release version="0.1.9" date="2020-2-18">
-            <description translatable="no">
+            <description translate="no">
                 <p>Add/remove packages dialog, improved HiDPI support, ...</p>
             </description>
         </release>
         <release version="0.1.8" date="2020-1-25">
-            <description translatable="no">
+            <description translate="no">
                 <p>Keyboard shortcuts in popovers, more commands in shortcuts bar, ...</p>
             </description>
         </release>
         <release version="0.1.7" date="2020-1-18">
-            <description translatable="no">
+            <description translate="no">
                 <p>More commands in shortcuts bar, autocomplete now case insensitive, ...</p>
             </description>
         </release>
         <release version="0.1.6" date="2020-1-13">
-            <description translatable="no">
+            <description translate="no">
                 <p>HiDPI support in .pdf preview, presistent code folding, ...</p>
             </description>
         </release>
         <release version="0.1.5" date="2020-1-3">
-            <description translatable="no">
+            <description translate="no">
                 <p>Initial code folding support, ...</p>
             </description>
         </release>
         <release version="0.1.4" date="2019-12-28">
-            <description translatable="no">
+            <description translate="no">
                 <p>References to existing labels in autocomplete, persistent root document state, ...</p>
             </description>
         </release>
         <release version="0.1.3" date="2019-12-21">
-            <description translatable="no">
+            <description translate="no">
                 <p>Initial spellchecking support, ...</p>
             </description>
         </release>
         <release version="0.1.2" date="2019-12-15">
-            <description translatable="no">
+            <description translate="no">
                 <p>Simple BibTeX wizard, more bibliography features in LaTeX editor, ...</p>
             </description>
         </release>
         <release version="0.1.1" date="2019-12-1">
-            <description translatable="no">
+            <description translate="no">
                 <p>BibTeX support in the build system, edit BibTeX files, ...</p>
             </description>
         </release>
         <release version="0.1.0" date="2019-11-27">
-            <description translatable="no">
+            <description translate="no">
                 <p>Editor settings in preferences dialog, ...</p>
             </description>
         </release>
         <release version="0.0.7" date="2019-11-24">
-            <description translatable="no">
+            <description translate="no">
                 <p>Build multiple times to resolve undefined references, show warnings in build log, ...</p>
             </description>
         </release>
         <release version="0.0.6" date="2019-11-21">
-            <description translatable="no">
+            <description translate="no">
                 <p>Indent multi-line inserts, ...</p>
             </description>
         </release>
         <release version="0.0.5" date="2019-11-14">
-            <description translatable="no">
+            <description translate="no">
                 <p>Multiple documents in build log, build in temporary folder, ...</p>
             </description>
         </release>
         <release version="0.0.4" date="2019-11-11">
-            <description translatable="no">
+            <description translate="no">
                 <p>Root document function, ...</p>
             </description>
         </release>
         <release version="0.0.3" date="2019-11-6">
-            <description translatable="no">
+            <description translate="no">
                 <p>New app layout, animated wizard button, big code refactor, ...</p>
             </description>
         </release>
         <release version="0.0.2" date="2019-10-22">
-            <description translatable="no">
+            <description translate="no">
                 <p>Set margins in wizard, improved icon, ...</p>
             </description>
         </release>
         ​<release version="0.0.1" date="2019-10-13">
-            <description translatable="no">
+            <description translate="no">
                 <p>Initial release</p>
             </description>
         </release>

--- a/data/org.cvfosammmm.Setzer.metainfo.xml.in
+++ b/data/org.cvfosammmm.Setzer.metainfo.xml.in
@@ -7,6 +7,9 @@
     <name translate="no">Setzer</name>
     <summary>Simple yet full-featured LaTeX editor</summary>
     <developer_name translate="no">Cvfosammmm</developer_name>
+    <developer id="org.cvfosammmm">
+        <name translate="no">Cvfosammmm</name>
+    </developer>
 
     <description>
         <p>Setzer lets you Write LaTeX documents with an easy to use yet full-featured editor.</p>


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer